### PR TITLE
feature: allow multiple rally group notifications

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -64,6 +64,25 @@ defmodule RuntimeConfig do
   end
 
   def parse_list(_), do: []
+
+  def parse_numeric_id_list(value) when is_binary(value) do
+    value
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.filter(fn id -> id != "" end)
+    |> Enum.map(fn id ->
+      case Integer.parse(id) do
+        {num, ""} -> num
+        _ -> nil
+      end
+    end)
+    |> Enum.filter(&is_integer/1)
+    |> Enum.uniq()
+  end
+
+  def parse_numeric_id_list(nil), do: []
+  def parse_numeric_id_list(""), do: []
+  def parse_numeric_id_list(_), do: []
 end
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -105,12 +124,10 @@ config :wanderer_notifier,
   discord_character_channel_id: RuntimeConfig.get_env("DISCORD_CHARACTER_CHANNEL_ID"),
   discord_rally_channel_id: RuntimeConfig.get_env("DISCORD_RALLY_CHANNEL_ID"),
   discord_rally_group_ids:
-    (case RuntimeConfig.get_env("DISCORD_RALLY_GROUP_IDS") ||
-            RuntimeConfig.get_env("DISCORD_RALLY_GROUP_ID") do
-       nil -> []
-       "" -> []
-       v -> v |> RuntimeConfig.parse_list() |> Enum.uniq()
-     end),
+    RuntimeConfig.parse_numeric_id_list(
+      RuntimeConfig.get_env("DISCORD_RALLY_GROUP_IDS") ||
+        RuntimeConfig.get_env("DISCORD_RALLY_GROUP_ID")
+    ),
 
   # Map settings
   map_token: RuntimeConfig.get_env("MAP_API_KEY"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -104,7 +104,13 @@ config :wanderer_notifier,
   discord_system_channel_id: RuntimeConfig.get_env("DISCORD_SYSTEM_CHANNEL_ID"),
   discord_character_channel_id: RuntimeConfig.get_env("DISCORD_CHARACTER_CHANNEL_ID"),
   discord_rally_channel_id: RuntimeConfig.get_env("DISCORD_RALLY_CHANNEL_ID"),
-  discord_rally_group_ids: WandererNotifier.Shared.Config.discord_rally_group_ids(),
+  discord_rally_group_ids:
+    (case RuntimeConfig.get_env("DISCORD_RALLY_GROUP_IDS") ||
+            RuntimeConfig.get_env("DISCORD_RALLY_GROUP_ID") do
+       nil -> []
+       "" -> []
+       v -> v |> RuntimeConfig.parse_list() |> Enum.uniq()
+     end),
 
   # Map settings
   map_token: RuntimeConfig.get_env("MAP_API_KEY"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -104,7 +104,7 @@ config :wanderer_notifier,
   discord_system_channel_id: RuntimeConfig.get_env("DISCORD_SYSTEM_CHANNEL_ID"),
   discord_character_channel_id: RuntimeConfig.get_env("DISCORD_CHARACTER_CHANNEL_ID"),
   discord_rally_channel_id: RuntimeConfig.get_env("DISCORD_RALLY_CHANNEL_ID"),
-  discord_rally_group_id: RuntimeConfig.get_env("DISCORD_RALLY_GROUP_ID"),
+  discord_rally_group_ids: WandererNotifier.Shared.Config.discord_rally_group_ids(),
 
   # Map settings
   map_token: RuntimeConfig.get_env("MAP_API_KEY"),

--- a/lib/wanderer_notifier/discord_notifier.ex
+++ b/lib/wanderer_notifier/discord_notifier.ex
@@ -299,12 +299,13 @@ defmodule WandererNotifier.DiscordNotifier do
   end
 
   defp build_rally_content do
-    case Config.discord_rally_group_ids() do
-      [] ->
+    alias WandererNotifier.Domains.Notifications.Formatters.NotificationUtils
+
+    case NotificationUtils.rally_mentions() do
+      "" ->
         "Rally point created!"
 
-      group_ids ->
-        mentions = Enum.map(group_ids, fn id -> "<@&#{id}>" end) |> Enum.join(" ")
+      mentions ->
         "#{mentions} Rally point created!"
     end
   end

--- a/lib/wanderer_notifier/discord_notifier.ex
+++ b/lib/wanderer_notifier/discord_notifier.ex
@@ -299,9 +299,13 @@ defmodule WandererNotifier.DiscordNotifier do
   end
 
   defp build_rally_content do
-    case Config.discord_rally_group_id() do
-      nil -> "Rally point created!"
-      group_id -> "<@&#{group_id}> Rally point created!"
+    case Config.discord_rally_group_ids() do
+      [] ->
+        "Rally point created!"
+
+      group_ids ->
+        mentions = Enum.map(group_ids, fn id -> "<@&#{id}>" end) |> Enum.join(" ")
+        "#{mentions} Rally point created!"
     end
   end
 

--- a/lib/wanderer_notifier/domains/notifications/discord/neo_client.ex
+++ b/lib/wanderer_notifier/domains/notifications/discord/neo_client.ex
@@ -149,6 +149,11 @@ defmodule WandererNotifier.Domains.Notifications.Notifiers.Discord.NeoClient do
       max_backoff: 10_000,
       jitter: false,
       context: "Discord API call",
+      # IMPORTANT: Don't retry on timeouts to prevent duplicate messages
+      # Only retry on definitive connection failures
+      retryable_errors: [:econnrefused, :ehostunreach, :enetunreach, :econnreset],
+      # Still retry on rate limits and server errors (except 408 timeout)
+      retryable_status_codes: [429, 500, 502, 503, 504],
       on_retry: fn attempt, error, delay ->
         elapsed = System.monotonic_time(:millisecond) - start_time
         log_retry_attempt(attempt, error, delay, elapsed, rally_id, channel_id_int)

--- a/lib/wanderer_notifier/domains/notifications/discord/notifier.ex
+++ b/lib/wanderer_notifier/domains/notifications/discord/notifier.ex
@@ -343,12 +343,13 @@ defmodule WandererNotifier.Domains.Notifications.Notifiers.Discord.Notifier do
   end
 
   defp build_rally_content(_rally_point) do
-    group_id = Config.discord_rally_group_id()
+    case Config.discord_rally_group_ids() do
+      [] ->
+        "Rally point created!"
 
-    if group_id do
-      "<@&#{group_id}> Rally point created!"
-    else
-      "Rally point created!"
+      group_ids ->
+        mentions = Enum.map(group_ids, fn id -> "<@&#{id}>" end) |> Enum.join(" ")
+        "#{mentions} Rally point created!"
     end
   end
 

--- a/lib/wanderer_notifier/domains/notifications/discord/notifier.ex
+++ b/lib/wanderer_notifier/domains/notifications/discord/notifier.ex
@@ -343,12 +343,13 @@ defmodule WandererNotifier.Domains.Notifications.Notifiers.Discord.Notifier do
   end
 
   defp build_rally_content(_rally_point) do
-    case Config.discord_rally_group_ids() do
-      [] ->
+    alias WandererNotifier.Domains.Notifications.Formatters.NotificationUtils
+
+    case NotificationUtils.rally_mentions() do
+      "" ->
         "Rally point created!"
 
-      group_ids ->
-        mentions = Enum.map(group_ids, fn id -> "<@&#{id}>" end) |> Enum.join(" ")
+      mentions ->
         "#{mentions} Rally point created!"
     end
   end

--- a/lib/wanderer_notifier/domains/notifications/formatters/killmail_formatter.ex
+++ b/lib/wanderer_notifier/domains/notifications/formatters/killmail_formatter.ex
@@ -344,12 +344,14 @@ defmodule WandererNotifier.Domains.Notifications.Formatters.KillmailFormatter do
   defp generate_message_id(%Killmail{killmail_id: killmail_id, kill_time: kill_time}) do
     # Create a hash of the killmail ID and timestamp for uniqueness
     # Use first 8 chars of hash for brevity
-    data = "#{killmail_id}-#{kill_time}"
+    # Normalize nils to empty strings to ensure predictable data
+    normalized_id = killmail_id || ""
+    normalized_time = kill_time || ""
+    data = "#{normalized_id}-#{normalized_time}"
 
     :crypto.hash(:sha256, data)
-    |> Base.encode16()
+    |> Base.encode16(case: :lower)
     |> String.slice(0..7)
-    |> String.downcase()
   end
 
   defp create_character_link(name, nil), do: "**#{name}**"

--- a/lib/wanderer_notifier/domains/notifications/formatters/killmail_formatter.ex
+++ b/lib/wanderer_notifier/domains/notifications/formatters/killmail_formatter.ex
@@ -347,16 +347,16 @@ defmodule WandererNotifier.Domains.Notifications.Formatters.KillmailFormatter do
     Utils.build_footer("ID: #{message_id}")
   end
 
+  @spec generate_message_id(Killmail.t()) :: <<_::64>>
   defp generate_message_id(%Killmail{killmail_id: killmail_id, kill_time: kill_time} = killmail) do
     # Create a hash of the killmail ID and timestamp for uniqueness
     # Use first 8 chars of hash for brevity
     id_part = normalize_id_part(killmail_id)
     time_part = normalize_time_part(kill_time)
 
-    data = build_hash_data(id_part, time_part, killmail)
+    data = build_seed(id_part, time_part, killmail)
 
-    hash = :crypto.hash(:sha256, data) |> Base.encode16(case: :lower)
-    binary_part(hash, 0, 8)
+    hash8(data)
   end
 
   defp normalize_id_part(nil), do: "nil"
@@ -365,12 +365,12 @@ defmodule WandererNotifier.Domains.Notifications.Formatters.KillmailFormatter do
   defp normalize_time_part(kill_time) when is_binary(kill_time) and kill_time != "", do: kill_time
   defp normalize_time_part(_), do: "nil"
 
-  defp build_hash_data("nil", "nil", killmail) do
+  defp build_seed("nil", "nil", killmail) do
     # Generate deterministic data based on available fields when both ID and time are missing
     generate_fallback_data(killmail)
   end
 
-  defp build_hash_data(id_part, time_part, _killmail) do
+  defp build_seed(id_part, time_part, _killmail) do
     id_part <> "-" <> time_part
   end
 
@@ -388,13 +388,21 @@ defmodule WandererNotifier.Domains.Notifications.Formatters.KillmailFormatter do
     }
 
     # Sort keys and create stable string representation
-    sorted_pairs =
-      deterministic_data
-      |> Enum.sort_by(fn {k, _v} -> k end)
-      |> Enum.map(fn {k, v} -> "#{k}=#{inspect(v)}" end)
-      |> Enum.join("-")
+    sorted_pairs = stable_pairs(deterministic_data)
 
     "fallback-#{sorted_pairs}"
+  end
+
+  defp stable_pairs(map) do
+    map
+    |> Enum.sort_by(fn {k, _v} -> k end)
+    |> Enum.map(fn {k, v} -> "#{k}=#{inspect(v)}" end)
+    |> Enum.join("-")
+  end
+
+  @spec hash8(binary()) :: <<_::64>>
+  defp hash8(data) do
+    :crypto.hash(:sha256, data) |> Base.encode16(case: :lower) |> binary_part(0, 8)
   end
 
   defp create_character_link(name, nil), do: "**#{name}**"

--- a/lib/wanderer_notifier/domains/notifications/formatters/killmail_formatter.ex
+++ b/lib/wanderer_notifier/domains/notifications/formatters/killmail_formatter.ex
@@ -61,7 +61,7 @@ defmodule WandererNotifier.Domains.Notifications.Formatters.KillmailFormatter do
       author: build_kill_author_icon(killmail),
       thumbnail: build_kill_thumbnail(killmail),
       fields: [],
-      footer: nil,
+      footer: build_kill_footer(killmail),
       timestamp: nil
     }
   end
@@ -332,6 +332,25 @@ defmodule WandererNotifier.Domains.Notifications.Formatters.KillmailFormatter do
   # ══════════════════════════════════════════════════════════════════════════════
   # Helper Functions
   # ══════════════════════════════════════════════════════════════════════════════
+
+  defp build_kill_footer(%Killmail{} = killmail) do
+    # Generate a unique message ID based on killmail_id and timestamp
+    # This helps identify potential duplicate messages
+    message_id = generate_message_id(killmail)
+
+    Utils.build_footer("ID: #{message_id}")
+  end
+
+  defp generate_message_id(%Killmail{killmail_id: killmail_id, kill_time: kill_time}) do
+    # Create a hash of the killmail ID and timestamp for uniqueness
+    # Use first 8 chars of hash for brevity
+    data = "#{killmail_id}-#{kill_time}"
+
+    :crypto.hash(:sha256, data)
+    |> Base.encode16()
+    |> String.slice(0..7)
+    |> String.downcase()
+  end
 
   defp create_character_link(name, nil), do: "**#{name}**"
 

--- a/lib/wanderer_notifier/domains/notifications/formatters/notification_utils.ex
+++ b/lib/wanderer_notifier/domains/notifications/formatters/notification_utils.ex
@@ -5,6 +5,7 @@ defmodule WandererNotifier.Domains.Notifications.Formatters.NotificationUtils do
   """
 
   alias WandererNotifier.Shared.Utils.FormattingUtils
+  alias WandererNotifier.Shared.Config
 
   # ═══════════════════════════════════════════════════════════════════════════════
   # URL Generation
@@ -250,11 +251,7 @@ defmodule WandererNotifier.Domains.Notifications.Formatters.NotificationUtils do
 
   @doc "Build rally group mentions from configured IDs"
   def rally_mentions do
-    alias WandererNotifier.Shared.Config
-
-    Config.discord_rally_group_ids()
-    |> Enum.map(fn id -> "<@&#{id}>" end)
-    |> Enum.join(" ")
+    Enum.map_join(Config.discord_rally_group_ids(), " ", fn id -> "<@&#{id}>" end)
   end
 
   # ═══════════════════════════════════════════════════════════════════════════════

--- a/lib/wanderer_notifier/domains/notifications/formatters/notification_utils.ex
+++ b/lib/wanderer_notifier/domains/notifications/formatters/notification_utils.ex
@@ -245,6 +245,19 @@ defmodule WandererNotifier.Domains.Notifications.Formatters.NotificationUtils do
   def get_system_icon(_), do: @system_icons.wormhole
 
   # ═══════════════════════════════════════════════════════════════════════════════
+  # Rally Mentions
+  # ═══════════════════════════════════════════════════════════════════════════════
+
+  @doc "Build rally group mentions from configured IDs"
+  def rally_mentions do
+    alias WandererNotifier.Shared.Config
+
+    Config.discord_rally_group_ids()
+    |> Enum.map(fn id -> "<@&#{id}>" end)
+    |> Enum.join(" ")
+  end
+
+  # ═══════════════════════════════════════════════════════════════════════════════
   # Field Building
   # ═══════════════════════════════════════════════════════════════════════════════
 

--- a/lib/wanderer_notifier/infrastructure/cache.ex
+++ b/lib/wanderer_notifier/infrastructure/cache.ex
@@ -38,6 +38,7 @@ defmodule WandererNotifier.Infrastructure.Cache do
   @map_data_ttl :timer.hours(1)
   @item_price_ttl :timer.hours(6)
   @license_ttl :timer.minutes(20)
+  @notification_dedup_ttl :timer.minutes(30)
 
   @type cache_key :: String.t()
   @type cache_value :: term()
@@ -68,6 +69,7 @@ defmodule WandererNotifier.Infrastructure.Cache do
   def ttl(:map_data), do: @map_data_ttl
   def ttl(:item_price), do: @item_price_ttl
   def ttl(:license), do: @license_ttl
+  def ttl(:notification_dedup), do: @notification_dedup_ttl
   def ttl(:health_check), do: :timer.seconds(1)
   def ttl(_), do: @default_ttl
 

--- a/lib/wanderer_notifier/shared/config.ex
+++ b/lib/wanderer_notifier/shared/config.ex
@@ -44,8 +44,21 @@ defmodule WandererNotifier.Shared.Config do
   @doc "Get Discord system kill channel ID (optional)"
   def discord_system_kill_channel_id, do: get_env_private("DISCORD_SYSTEM_KILL_CHANNEL_ID")
 
-  @doc "Get Discord rally group ID (optional)"
-  def discord_rally_group_id, do: get_env_private("DISCORD_RALLY_GROUP_ID")
+  @doc "Get Discord rally group IDs (optional) - returns a list of group IDs from comma-separated string"
+  def discord_rally_group_ids do
+    case get_env_private("DISCORD_RALLY_GROUP_ID") do
+      nil ->
+        []
+
+      "" ->
+        []
+
+      value ->
+        value
+        |> String.split(",", trim: true)
+        |> Enum.map(&String.trim/1)
+    end
+  end
 
   @doc "Get all Discord channel configuration in a single call"
   def discord_channels do

--- a/lib/wanderer_notifier/shared/config.ex
+++ b/lib/wanderer_notifier/shared/config.ex
@@ -46,7 +46,11 @@ defmodule WandererNotifier.Shared.Config do
 
   @doc "Get Discord rally group IDs (optional) - returns a list of group IDs from comma-separated string"
   def discord_rally_group_ids do
-    case get_env_private("DISCORD_RALLY_GROUP_ID") do
+    # Check plural first, then fall back to singular
+    value =
+      get_env_private("DISCORD_RALLY_GROUP_IDS") || get_env_private("DISCORD_RALLY_GROUP_ID")
+
+    case value do
       nil ->
         []
 
@@ -57,6 +61,11 @@ defmodule WandererNotifier.Shared.Config do
         value
         |> String.split(",", trim: true)
         |> Enum.map(&String.trim/1)
+        |> Enum.filter(fn id ->
+          # Filter out non-numeric entries
+          String.match?(id, ~r/^\d+$/)
+        end)
+        |> Enum.uniq()
     end
   end
 

--- a/lib/wanderer_notifier/shared/config.ex
+++ b/lib/wanderer_notifier/shared/config.ex
@@ -44,29 +44,9 @@ defmodule WandererNotifier.Shared.Config do
   @doc "Get Discord system kill channel ID (optional)"
   def discord_system_kill_channel_id, do: get_env_private("DISCORD_SYSTEM_KILL_CHANNEL_ID")
 
-  @doc "Get Discord rally group IDs (optional) - returns a list of group IDs from comma-separated string"
+  @doc "Get Discord rally group IDs (optional) - returns a list of numeric group IDs"
   def discord_rally_group_ids do
-    # Check plural first, then fall back to singular
-    value =
-      get_env_private("DISCORD_RALLY_GROUP_IDS") || get_env_private("DISCORD_RALLY_GROUP_ID")
-
-    case value do
-      nil ->
-        []
-
-      "" ->
-        []
-
-      value ->
-        value
-        |> String.split(",", trim: true)
-        |> Enum.map(&String.trim/1)
-        |> Enum.filter(fn id ->
-          # Filter out non-numeric entries
-          String.match?(id, ~r/^\d+$/)
-        end)
-        |> Enum.uniq()
-    end
+    Application.get_env(:wanderer_notifier, :discord_rally_group_ids, [])
   end
 
   @doc "Get all Discord channel configuration in a single call"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule WandererNotifier.MixProject do
   def project do
     [
       app: :wanderer_notifier,
-      version: "3.3.9",
+      version: "3.4.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/support/helpers/cache_test_helper.ex
+++ b/test/support/helpers/cache_test_helper.ex
@@ -18,9 +18,11 @@ defmodule WandererNotifier.Test.Helpers.CacheTestHelper do
       assert_cache_put("test:key", "test_value")
       assert_cache_put(Cache.Keys.map_characters(), characters)
   """
+  @spec assert_cache_put(term(), term()) :: :ok
   def assert_cache_put(key, value) do
     assert :ok = Cache.put(key, value)
     assert {:ok, ^value} = Cache.get(key)
+    :ok
   end
 
   @doc """
@@ -30,8 +32,10 @@ defmodule WandererNotifier.Test.Helpers.CacheTestHelper do
 
       assert_cache_put("test:key", "test_value", :timer.hours(1))
   """
+  @spec assert_cache_put(term(), term(), integer()) :: :ok
   def assert_cache_put(key, value, ttl) do
     assert :ok = Cache.put(key, value, ttl)
     assert {:ok, ^value} = Cache.get(key)
+    :ok
   end
 end

--- a/test/support/helpers/cache_test_helper.ex
+++ b/test/support/helpers/cache_test_helper.ex
@@ -1,0 +1,37 @@
+defmodule WandererNotifier.Test.Helpers.CacheTestHelper do
+  @moduledoc """
+  Helper functions for cache assertions in tests.
+  """
+
+  alias WandererNotifier.Infrastructure.Cache
+
+  import ExUnit.Assertions
+
+  @doc """
+  Asserts that a Cache.put operation succeeds and the value is correctly stored.
+
+  This helper improves test determinism by verifying both the put operation
+  and that the value can be retrieved.
+
+  ## Examples
+
+      assert_cache_put("test:key", "test_value")
+      assert_cache_put(Cache.Keys.map_characters(), characters)
+  """
+  def assert_cache_put(key, value) do
+    assert :ok = Cache.put(key, value)
+    assert {:ok, ^value} = Cache.get(key)
+  end
+
+  @doc """
+  Asserts that a Cache.put operation with TTL succeeds and the value is correctly stored.
+
+  ## Examples
+
+      assert_cache_put("test:key", "test_value", :timer.hours(1))
+  """
+  def assert_cache_put(key, value, ttl) do
+    assert :ok = Cache.put(key, value, ttl)
+    assert {:ok, ^value} = Cache.get(key)
+  end
+end

--- a/test/support/helpers/cache_test_helper.ex
+++ b/test/support/helpers/cache_test_helper.ex
@@ -28,12 +28,18 @@ defmodule WandererNotifier.Test.Helpers.CacheTestHelper do
   @doc """
   Asserts that a Cache.put operation with TTL succeeds and the value is correctly stored.
 
+  The TTL must be a positive integer (milliseconds).
+
   ## Examples
 
       assert_cache_put("test:key", "test_value", :timer.hours(1))
   """
-  @spec assert_cache_put(term(), term(), integer()) :: :ok
+  @spec assert_cache_put(term(), term(), non_neg_integer()) :: :ok
   def assert_cache_put(key, value, ttl) do
+    # Validate TTL is a positive integer
+    assert is_integer(ttl) and ttl > 0,
+           "TTL must be a positive integer (milliseconds), got: #{inspect(ttl)}"
+
     assert :ok = Cache.put(key, value, ttl)
     assert {:ok, ^value} = Cache.get(key)
     :ok

--- a/test/wanderer_notifier/api/api_test.exs
+++ b/test/wanderer_notifier/api/api_test.exs
@@ -1,5 +1,5 @@
 defmodule WandererNotifier.API.APITest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Mox
   alias WandererNotifier.Test.Fixtures.ApiResponses
 

--- a/test/wanderer_notifier/api/api_test.exs
+++ b/test/wanderer_notifier/api/api_test.exs
@@ -1,5 +1,5 @@
 defmodule WandererNotifier.API.APITest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   import Mox
   alias WandererNotifier.Test.Fixtures.ApiResponses
 

--- a/test/wanderer_notifier/domains/tracking/entities/character_test.exs
+++ b/test/wanderer_notifier/domains/tracking/entities/character_test.exs
@@ -1,5 +1,5 @@
 defmodule WandererNotifier.Domains.Tracking.Entities.CharacterTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias WandererNotifier.Domains.Tracking.Entities.Character
   alias WandererNotifier.Infrastructure.Cache

--- a/test/wanderer_notifier/domains/tracking/entities/character_test.exs
+++ b/test/wanderer_notifier/domains/tracking/entities/character_test.exs
@@ -4,6 +4,8 @@ defmodule WandererNotifier.Domains.Tracking.Entities.CharacterTest do
   alias WandererNotifier.Domains.Tracking.Entities.Character
   alias WandererNotifier.Infrastructure.Cache
 
+  import WandererNotifier.Test.Helpers.CacheTestHelper
+
   setup do
     # Clear the cache before each test
     Cache.delete(Cache.Keys.map_characters())
@@ -164,7 +166,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.CharacterTest do
         %{"eve_id" => "789012", "name" => "Another Character"}
       ]
 
-      Cache.put(Cache.Keys.map_characters(), characters)
+      assert_cache_put(Cache.Keys.map_characters(), characters)
 
       assert {:ok, true} = Character.is_tracked?("123456")
     end
@@ -174,7 +176,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.CharacterTest do
         %{"eve_id" => "789012", "name" => "Another Character"}
       ]
 
-      Cache.put(Cache.Keys.map_characters(), characters)
+      assert_cache_put(Cache.Keys.map_characters(), characters)
 
       assert {:ok, false} = Character.is_tracked?("123456")
     end
@@ -189,7 +191,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.CharacterTest do
         %{"eve_id" => "123456", "name" => "Test Character"}
       ]
 
-      Cache.put(Cache.Keys.map_characters(), characters)
+      assert_cache_put(Cache.Keys.map_characters(), characters)
 
       assert {:ok, true} = Character.is_tracked?(123_456)
     end
@@ -207,7 +209,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.CharacterTest do
         %{"eve_id" => "789012", "name" => "Another Character"}
       ]
 
-      Cache.put(Cache.Keys.map_characters(), characters)
+      assert_cache_put(Cache.Keys.map_characters(), characters)
 
       assert {:ok, character} = Character.get_character("123456")
       assert character.name == "Test Character"
@@ -218,7 +220,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.CharacterTest do
         %{"eve_id" => "789012", "name" => "Another Character"}
       ]
 
-      Cache.put(Cache.Keys.map_characters(), characters)
+      assert_cache_put(Cache.Keys.map_characters(), characters)
 
       assert {:error, :not_found} = Character.get_character("123456")
     end

--- a/test/wanderer_notifier/domains/tracking/entities/system_test.exs
+++ b/test/wanderer_notifier/domains/tracking/entities/system_test.exs
@@ -4,6 +4,8 @@ defmodule WandererNotifier.Domains.Tracking.Entities.SystemTest do
   alias WandererNotifier.Domains.Tracking.Entities.System
   alias WandererNotifier.Infrastructure.Cache
 
+  import WandererNotifier.Test.Helpers.CacheTestHelper
+
   setup do
     # Clear the cache before each test
     Cache.delete("map:systems")
@@ -135,7 +137,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.SystemTest do
         %{"solar_system_id" => "30002659", "name" => "Rancer"}
       ]
 
-      Cache.put("map:systems", systems)
+      assert_cache_put("map:systems", systems)
 
       assert {:ok, true} = System.is_tracked?("30000142")
     end
@@ -145,7 +147,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.SystemTest do
         %{"solar_system_id" => "30002659", "name" => "Rancer"}
       ]
 
-      Cache.put("map:systems", systems)
+      assert_cache_put("map:systems", systems)
 
       assert {:ok, false} = System.is_tracked?("30000142")
     end
@@ -160,7 +162,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.SystemTest do
         %{"solar_system_id" => "30000142", "name" => "Jita"}
       ]
 
-      Cache.put("map:systems", systems)
+      assert_cache_put("map:systems", systems)
 
       assert {:ok, true} = System.is_tracked?(30_000_142)
     end
@@ -178,7 +180,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.SystemTest do
         %{"solar_system_id" => "30002659", "name" => "Rancer"}
       ]
 
-      Cache.put("map:systems", systems)
+      assert_cache_put("map:systems", systems)
 
       assert {:ok, system} = System.get_system("30000142")
       assert system.name == "Jita"
@@ -189,7 +191,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.SystemTest do
         %{"solar_system_id" => "30002659", "name" => "Rancer"}
       ]
 
-      Cache.put("map:systems", systems)
+      assert_cache_put("map:systems", systems)
 
       assert {:error, :not_found} = System.get_system("30000142")
     end
@@ -207,7 +209,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.SystemTest do
         %{"solar_system_id" => "30002659", "name" => "Rancer"}
       ]
 
-      Cache.put("map:systems", systems)
+      assert_cache_put("map:systems", systems)
 
       assert {:ok, system} = System.get_system_by_name("Jita")
       assert system.solar_system_id == 30_000_142
@@ -218,7 +220,7 @@ defmodule WandererNotifier.Domains.Tracking.Entities.SystemTest do
         %{"solar_system_id" => "30002659", "name" => "Rancer"}
       ]
 
-      Cache.put("map:systems", systems)
+      assert_cache_put("map:systems", systems)
 
       assert {:error, :not_found} = System.get_system_by_name("Jita")
     end

--- a/test/wanderer_notifier/domains/tracking/entities/system_test.exs
+++ b/test/wanderer_notifier/domains/tracking/entities/system_test.exs
@@ -1,5 +1,5 @@
 defmodule WandererNotifier.Domains.Tracking.Entities.SystemTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias WandererNotifier.Domains.Tracking.Entities.System
   alias WandererNotifier.Infrastructure.Cache

--- a/test/wanderer_notifier/domains/tracking/handlers/character_handler_test.exs
+++ b/test/wanderer_notifier/domains/tracking/handlers/character_handler_test.exs
@@ -6,6 +6,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.CharacterHandlerTest do
 
   import ExUnit.CaptureLog
   import Mox
+  import WandererNotifier.Test.Helpers.CacheTestHelper
 
   setup :verify_on_exit!
 
@@ -33,11 +34,8 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.CharacterHandlerTest do
         }
       ]
 
-      # Ensure cache operation succeeds
-      assert :ok = Cache.put(Cache.Keys.map_characters(), existing_characters)
-
-      # Verify data was actually stored
-      assert {:ok, ^existing_characters} = Cache.get(Cache.Keys.map_characters())
+      # Ensure cache operation succeeds and verify data was actually stored
+      assert_cache_put(Cache.Keys.map_characters(), existing_characters)
 
       # Create removal event
       event = %{
@@ -71,7 +69,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.CharacterHandlerTest do
         }
       ]
 
-      Cache.put(Cache.Keys.map_characters(), existing_characters)
+      assert_cache_put(Cache.Keys.map_characters(), existing_characters)
 
       # Create removal event for non-existent character
       event = %{
@@ -133,7 +131,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.CharacterHandlerTest do
         }
       ]
 
-      Cache.put(Cache.Keys.map_characters(), existing_characters)
+      assert_cache_put(Cache.Keys.map_characters(), existing_characters)
 
       # Create removal event
       event = %{
@@ -166,7 +164,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.CharacterHandlerTest do
         }
       ]
 
-      Cache.put(Cache.Keys.map_characters(), existing_characters)
+      assert_cache_put(Cache.Keys.map_characters(), existing_characters)
 
       # Create removal event
       event = %{
@@ -231,7 +229,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.CharacterHandlerTest do
         }
       ]
 
-      Cache.put(Cache.Keys.map_characters(), existing_characters)
+      assert_cache_put(Cache.Keys.map_characters(), existing_characters)
 
       # Try to add same character again
       event = %{
@@ -274,7 +272,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.CharacterHandlerTest do
         }
       ]
 
-      Cache.put(Cache.Keys.map_characters(), existing_characters)
+      assert_cache_put(Cache.Keys.map_characters(), existing_characters)
 
       # Update event
       event = %{

--- a/test/wanderer_notifier/domains/tracking/handlers/character_handler_test.exs
+++ b/test/wanderer_notifier/domains/tracking/handlers/character_handler_test.exs
@@ -1,5 +1,5 @@
 defmodule WandererNotifier.Domains.Tracking.Handlers.CharacterHandlerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias WandererNotifier.Domains.Tracking.Handlers.CharacterHandler
   alias WandererNotifier.Infrastructure.Cache
@@ -33,7 +33,11 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.CharacterHandlerTest do
         }
       ]
 
-      Cache.put(Cache.Keys.map_characters(), existing_characters)
+      # Ensure cache operation succeeds
+      assert :ok = Cache.put(Cache.Keys.map_characters(), existing_characters)
+
+      # Verify data was actually stored
+      assert {:ok, ^existing_characters} = Cache.get(Cache.Keys.map_characters())
 
       # Create removal event
       event = %{

--- a/test/wanderer_notifier/domains/tracking/handlers/shared_event_logic_test.exs
+++ b/test/wanderer_notifier/domains/tracking/handlers/shared_event_logic_test.exs
@@ -1,5 +1,5 @@
 defmodule WandererNotifier.Domains.Tracking.Handlers.SharedEventLogicTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias WandererNotifier.Domains.Tracking.Handlers.SharedEventLogic
 

--- a/test/wanderer_notifier/domains/tracking/handlers/shared_event_logic_test.exs
+++ b/test/wanderer_notifier/domains/tracking/handlers/shared_event_logic_test.exs
@@ -1,12 +1,9 @@
 defmodule WandererNotifier.Domains.Tracking.Handlers.SharedEventLogicTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias WandererNotifier.Domains.Tracking.Handlers.SharedEventLogic
 
   import ExUnit.CaptureLog
-  import Mox
-
-  setup :verify_on_exit!
 
   describe "handle_entity_event/6" do
     test "successfully processes entity event" do

--- a/test/wanderer_notifier/domains/tracking/handlers/system_handler_test.exs
+++ b/test/wanderer_notifier/domains/tracking/handlers/system_handler_test.exs
@@ -7,6 +7,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandlerTest do
 
   import ExUnit.CaptureLog
   import Mox
+  import WandererNotifier.Test.Helpers.CacheTestHelper
 
   setup :verify_on_exit!
 
@@ -37,7 +38,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandlerTest do
       }
 
       existing_systems = [system1, system2]
-      Cache.put(Cache.Keys.map_systems(), existing_systems)
+      assert_cache_put(Cache.Keys.map_systems(), existing_systems)
 
       # Also add to individual system cache
       Cache.put_tracked_system("31000001", %{
@@ -78,7 +79,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandlerTest do
         region_name: "The Forge"
       }
 
-      Cache.put(Cache.Keys.map_systems(), [system1])
+      assert_cache_put(Cache.Keys.map_systems(), [system1])
 
       # Create removal event for non-existent system
       event = %{
@@ -134,7 +135,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandlerTest do
       }
 
       existing_systems = [system_with_id, map_with_solar_system_id, map_with_id]
-      Cache.put(Cache.Keys.map_systems(), existing_systems)
+      assert_cache_put(Cache.Keys.map_systems(), existing_systems)
 
       # Test removal by system ID
       event1 = %{
@@ -161,7 +162,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandlerTest do
         class_title: "C3"
       }
 
-      Cache.put(Cache.Keys.map_systems(), [system])
+      assert_cache_put(Cache.Keys.map_systems(), [system])
       Cache.put_tracked_system("31000001", %{"id" => 31_000_001, "name" => "J123456"})
 
       # Create removal event
@@ -292,7 +293,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandlerTest do
         statics: ["D845"]
       }
 
-      Cache.put(Cache.Keys.map_systems(), [existing_system])
+      assert_cache_put(Cache.Keys.map_systems(), [existing_system])
 
       # Try to add same system again with updated data
       event = %{
@@ -349,7 +350,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandlerTest do
         statics: ["D845"]
       }
 
-      Cache.put(Cache.Keys.map_systems(), [existing_system])
+      assert_cache_put(Cache.Keys.map_systems(), [existing_system])
 
       Cache.put_tracked_system("31000001", %{
         "id" => 31_000_001,

--- a/test/wanderer_notifier/domains/tracking/handlers/system_handler_test.exs
+++ b/test/wanderer_notifier/domains/tracking/handlers/system_handler_test.exs
@@ -1,5 +1,5 @@
 defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandlerTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias WandererNotifier.Domains.Tracking.Handlers.SystemHandler
   alias WandererNotifier.Domains.Tracking.Entities.System

--- a/test/wanderer_notifier/esi/client_test.exs
+++ b/test/wanderer_notifier/esi/client_test.exs
@@ -1,5 +1,5 @@
 defmodule WandererNotifier.Infrastructure.Adapters.ESI.ClientTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Mox
 
   alias WandererNotifier.Infrastructure.Adapters.ESI.Client

--- a/test/wanderer_notifier/esi/client_test.exs
+++ b/test/wanderer_notifier/esi/client_test.exs
@@ -4,18 +4,29 @@ defmodule WandererNotifier.Infrastructure.Adapters.ESI.ClientTest do
 
   alias WandererNotifier.Infrastructure.Adapters.ESI.Client
 
-  # Module attribute to control mock behavior in error cases
   @moduledoc false
 
   setup :verify_on_exit!
   setup :set_mox_from_context
 
   setup do
+    # Capture original value to restore after test
+    original_http_client = Application.get_env(:wanderer_notifier, :http_client)
+
     Application.put_env(
       :wanderer_notifier,
       :http_client,
       WandererNotifier.HTTPMock
     )
+
+    on_exit(fn ->
+      # Restore original value
+      if original_http_client do
+        Application.put_env(:wanderer_notifier, :http_client, original_http_client)
+      else
+        Application.delete_env(:wanderer_notifier, :http_client)
+      end
+    end)
 
     :ok
   end

--- a/test/wanderer_notifier/esi/client_test.exs
+++ b/test/wanderer_notifier/esi/client_test.exs
@@ -6,8 +6,8 @@ defmodule WandererNotifier.Infrastructure.Adapters.ESI.ClientTest do
 
   @moduledoc false
 
-  setup :verify_on_exit!
   setup :set_mox_from_context
+  setup :verify_on_exit!
 
   setup do
     # Capture original value to restore after test

--- a/test/wanderer_notifier/esi/service_test.exs
+++ b/test/wanderer_notifier/esi/service_test.exs
@@ -56,26 +56,53 @@ defmodule WandererNotifier.Infrastructure.Adapters.ESI.ServiceTest do
   # Stub the Client module
   setup do
     # Make sure the required registries are started
-    if !Process.whereis(WandererNotifier.Cache.Registry) do
-      {:ok, _} = Registry.start_link(keys: :unique, name: WandererNotifier.Cache.Registry)
-    end
+    started_registry? =
+      case Process.whereis(WandererNotifier.Cache.Registry) do
+        nil ->
+          {:ok, _} = Registry.start_link(keys: :unique, name: WandererNotifier.Cache.Registry)
+          true
+
+        _ ->
+          false
+      end
 
     # Make sure Cachex is started for testing
     cache_name = Application.get_env(:wanderer_notifier, :cache_name, :wanderer_test_cache)
 
     # Start Cachex if it's not already running
-    case Process.whereis(cache_name) do
-      nil ->
-        # Ensure Cachex application is started
-        Application.ensure_all_started(:cachex)
-        {:ok, _pid} = Cachex.start_link(name: cache_name, stats: true)
+    _cache_started? =
+      case Process.whereis(cache_name) do
+        nil ->
+          # Ensure Cachex application is started
+          Application.ensure_all_started(:cachex)
+          {:ok, _pid} = Cachex.start_link(name: cache_name, stats: true)
+          true
 
-      _pid ->
-        :ok
-    end
+        _pid ->
+          false
+      end
 
-    # Set the ESI client mock as the implementation
+    # Capture and set the ESI client mock as the implementation
+    prev_client = Application.get_env(:wanderer_notifier, :esi_client)
     Application.put_env(:wanderer_notifier, :esi_client, ServiceMock)
+
+    on_exit(fn ->
+      # Restore original ESI client
+      if prev_client do
+        Application.put_env(:wanderer_notifier, :esi_client, prev_client)
+      else
+        Application.delete_env(:wanderer_notifier, :esi_client)
+      end
+
+      # Clean up started processes
+      # Note: Cachex doesn't provide a stop/1 function, let supervisor handle cleanup
+      if started_registry? do
+        case Process.whereis(WandererNotifier.Cache.Registry) do
+          nil -> :ok
+          pid -> Process.exit(pid, :normal)
+        end
+      end
+    end)
 
     # Define mocks for ESI client calls
     ServiceMock

--- a/test/wanderer_notifier/esi/service_test.exs
+++ b/test/wanderer_notifier/esi/service_test.exs
@@ -1,5 +1,5 @@
 defmodule WandererNotifier.Infrastructure.Adapters.ESI.ServiceTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Mox
 
   alias WandererNotifier.Infrastructure.Adapters.ESI.Service

--- a/test/wanderer_notifier/infrastructure/cache_test.exs
+++ b/test/wanderer_notifier/infrastructure/cache_test.exs
@@ -114,7 +114,7 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       character_id = 12_345
       character_data = %{name: "Test Character", corp_id: 67_890}
 
-      # Put character data directly and verify it was stored
+      # Store character data via helper and verify it was stored
       key = Cache.Keys.character(character_id)
       assert_cache_put(key, character_data)
 
@@ -141,7 +141,7 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       key = Cache.Keys.corporation(corp_id)
       assert_cache_put(key, corp_data)
 
-      # Also verify using helper
+      # Also verify using helper (corporation)
       assert {:ok, ^corp_data} = Cache.get_corporation(corp_id)
     end
 
@@ -164,7 +164,7 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       key = Cache.Keys.alliance(alliance_id)
       assert_cache_put(key, alliance_data)
 
-      # Also verify using helper
+      # Also verify using get_alliance helper
       assert {:ok, ^alliance_data} = Cache.get_alliance(alliance_id)
     end
 
@@ -183,7 +183,7 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       system_id = 30_000_142
       system_data = %{name: "Jita", security_status: 0.9}
 
-      # Put system data directly and verify it was stored
+      # Put system data and verify it was stored using Cache.get_system helper
       key = Cache.Keys.system(system_id)
       assert_cache_put(key, system_data)
 
@@ -235,7 +235,7 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       assert {:error, :not_found} = Cache.get(key)
 
       # Mark as sent and verify
-      assert_cache_put(key, true, :timer.minutes(30))
+      assert_cache_put(key, true, Cache.ttl(:notification_dedup))
     end
   end
 
@@ -247,6 +247,7 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       assert Cache.ttl(:system) == :timer.hours(1)
       assert Cache.ttl(:killmail) == :timer.minutes(30)
       assert Cache.ttl(:map_data) == :timer.hours(1)
+      assert Cache.ttl(:notification_dedup) == :timer.minutes(30)
     end
 
     test "ttl/1 returns appropriate TTL" do

--- a/test/wanderer_notifier/infrastructure/cache_test.exs
+++ b/test/wanderer_notifier/infrastructure/cache_test.exs
@@ -3,6 +3,8 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
 
   alias WandererNotifier.Infrastructure.Cache
 
+  import WandererNotifier.Test.Helpers.CacheTestHelper
+
   setup do
     # Ensure Cachex is started for testing
     cache_name = Application.get_env(:wanderer_notifier, :cache_name, :wanderer_test_cache)
@@ -35,11 +37,8 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       key = "test:key"
       value = %{"name" => "test", "id" => 123}
 
-      # Put value
-      :ok = Cache.put(key, value)
-
-      # Get value
-      assert {:ok, ^value} = Cache.get(key)
+      # Put value and verify it was stored
+      assert_cache_put(key, value)
     end
 
     test "get returns error for non-existent key" do
@@ -52,11 +51,8 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       # 1 second
       ttl = 1000
 
-      # Put with TTL should succeed
-      :ok = Cache.put(key, value, ttl)
-
-      # Should exist immediately
-      assert {:ok, ^value} = Cache.get(key)
+      # Put with TTL should succeed and verify value exists
+      assert_cache_put(key, value, ttl)
 
       # Note: We don't test actual expiration as it's timing-dependent
       # and the important thing is that the TTL parameter is accepted
@@ -66,9 +62,8 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       key = "test:delete"
       value = "to be deleted"
 
-      # Put value
-      :ok = Cache.put(key, value)
-      assert {:ok, ^value} = Cache.get(key)
+      # Put value and verify it was stored
+      assert_cache_put(key, value)
 
       # Delete value
       :ok = Cache.delete(key)
@@ -119,11 +114,11 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       character_id = 12_345
       character_data = %{name: "Test Character", corp_id: 67_890}
 
-      # Put character data directly
+      # Put character data directly and verify it was stored
       key = Cache.Keys.character(character_id)
-      :ok = Cache.put(key, character_data)
+      assert_cache_put(key, character_data)
 
-      # Use helper to retrieve
+      # Also verify using helper
       assert {:ok, ^character_data} = Cache.get_character(character_id)
     end
 
@@ -142,11 +137,11 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       corp_id = 67_890
       corp_data = %{name: "Test Corp", ticker: "TEST"}
 
-      # Put corp data directly
+      # Put corp data directly and verify it was stored
       key = Cache.Keys.corporation(corp_id)
-      :ok = Cache.put(key, corp_data)
+      assert_cache_put(key, corp_data)
 
-      # Use helper to retrieve
+      # Also verify using helper
       assert {:ok, ^corp_data} = Cache.get_corporation(corp_id)
     end
 
@@ -165,11 +160,11 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       alliance_id = 111_222
       alliance_data = %{name: "Test Alliance", ticker: "TESTA"}
 
-      # Put alliance data directly
+      # Put alliance data directly and verify it was stored
       key = Cache.Keys.alliance(alliance_id)
-      :ok = Cache.put(key, alliance_data)
+      assert_cache_put(key, alliance_data)
 
-      # Use helper to retrieve
+      # Also verify using helper
       assert {:ok, ^alliance_data} = Cache.get_alliance(alliance_id)
     end
 
@@ -188,11 +183,11 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       system_id = 30_000_142
       system_data = %{name: "Jita", security_status: 0.9}
 
-      # Put system data directly
+      # Put system data directly and verify it was stored
       key = Cache.Keys.system(system_id)
-      :ok = Cache.put(key, system_data)
+      assert_cache_put(key, system_data)
 
-      # Use helper to retrieve
+      # Also verify using helper
       assert {:ok, ^system_data} = Cache.get_system(system_id)
     end
 
@@ -228,11 +223,8 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       # Initially not processed
       assert {:error, :not_found} = Cache.get(key)
 
-      # Mark as processed
-      :ok = Cache.put(key, true, Cache.ttl(:killmail))
-
-      # Should be marked as processed
-      assert {:ok, true} = Cache.get(key)
+      # Mark as processed and verify
+      assert_cache_put(key, true, Cache.ttl(:killmail))
     end
 
     test "can implement notification deduplication with basic cache ops" do
@@ -242,11 +234,8 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       # Initially not sent
       assert {:error, :not_found} = Cache.get(key)
 
-      # Mark as sent
-      :ok = Cache.put(key, true, :timer.minutes(30))
-
-      # Should be marked as sent
-      assert {:ok, true} = Cache.get(key)
+      # Mark as sent and verify
+      assert_cache_put(key, true, :timer.minutes(30))
     end
   end
 

--- a/test/wanderer_notifier/infrastructure/cache_test.exs
+++ b/test/wanderer_notifier/infrastructure/cache_test.exs
@@ -49,7 +49,7 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       key = "test:ttl"
       value = "expires eventually"
       # 1 second
-      ttl = 1000
+      ttl = :timer.seconds(1)
 
       # Put with TTL should succeed and verify value exists
       assert_cache_put(key, value, ttl)
@@ -78,7 +78,7 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
       refute Cache.exists?(key)
 
       # Put value
-      :ok = Cache.put(key, value)
+      assert_cache_put(key, value)
 
       # Key exists now
       assert Cache.exists?(key)
@@ -90,9 +90,9 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
 
     test "clear removes all cached values" do
       # Put multiple values
-      :ok = Cache.put("test:1", "value1")
-      :ok = Cache.put("test:2", "value2")
-      :ok = Cache.put("test:3", "value3")
+      assert_cache_put("test:1", "value1")
+      assert_cache_put("test:2", "value2")
+      assert_cache_put("test:3", "value3")
 
       # Verify they exist
       assert {:ok, "value1"} = Cache.get("test:1")
@@ -258,9 +258,9 @@ defmodule WandererNotifier.Infrastructure.CacheTest do
   describe "batch operations" do
     test "get_batch retrieves multiple keys efficiently" do
       # Put test data
-      :ok = Cache.put("batch:1", "value1")
-      :ok = Cache.put("batch:2", "value2")
-      :ok = Cache.put("batch:3", "value3")
+      assert_cache_put("batch:1", "value1")
+      assert_cache_put("batch:2", "value2")
+      assert_cache_put("batch:3", "value3")
 
       # Test batch get
       keys = ["batch:1", "batch:2", "batch:3", "batch:nonexistent"]

--- a/test/wanderer_notifier/integration/removal_events_test.exs
+++ b/test/wanderer_notifier/integration/removal_events_test.exs
@@ -4,8 +4,6 @@ defmodule WandererNotifier.Integration.RemovalEventsTest do
   alias WandererNotifier.Infrastructure.Cache
   alias WandererNotifier.Map.EventProcessor
 
-  import WandererNotifier.Test.Helpers.CacheTestHelper
-
   setup do
     # Clear cache before each test
     Cache.delete(Cache.Keys.map_characters())

--- a/test/wanderer_notifier/integration/removal_events_test.exs
+++ b/test/wanderer_notifier/integration/removal_events_test.exs
@@ -4,6 +4,8 @@ defmodule WandererNotifier.Integration.RemovalEventsTest do
   alias WandererNotifier.Infrastructure.Cache
   alias WandererNotifier.Map.EventProcessor
 
+  import WandererNotifier.Test.Helpers.CacheTestHelper
+
   setup do
     # Clear cache before each test
     Cache.delete(Cache.Keys.map_characters())

--- a/test/wanderer_notifier/integration/removal_events_test.exs
+++ b/test/wanderer_notifier/integration/removal_events_test.exs
@@ -4,6 +4,8 @@ defmodule WandererNotifier.Integration.RemovalEventsTest do
   alias WandererNotifier.Infrastructure.Cache
   alias WandererNotifier.Map.EventProcessor
 
+  import WandererNotifier.Test.Helpers.CacheTestHelper
+
   setup do
     # Clear cache before each test
     Cache.delete(Cache.Keys.map_characters())
@@ -33,7 +35,7 @@ defmodule WandererNotifier.Integration.RemovalEventsTest do
         }
       ]
 
-      Cache.put(Cache.Keys.map_characters(), characters)
+      assert_cache_put(Cache.Keys.map_characters(), characters)
 
       # Create SSE event
       event = %{
@@ -94,7 +96,7 @@ defmodule WandererNotifier.Integration.RemovalEventsTest do
         region_name: "W-Space"
       }
 
-      Cache.put(Cache.Keys.map_systems(), [system])
+      assert_cache_put(Cache.Keys.map_systems(), [system])
 
       Cache.put_tracked_system("31000001", %{
         "id" => 31_000_001,
@@ -173,7 +175,7 @@ defmodule WandererNotifier.Integration.RemovalEventsTest do
         %{"eve_id" => "444", "name" => "Char 4"}
       ]
 
-      Cache.put(Cache.Keys.map_characters(), characters)
+      assert_cache_put(Cache.Keys.map_characters(), characters)
 
       # Remove characters 2 and 3
       for eve_id <- ["222", "333"] do

--- a/test/wanderer_notifier/killmail/pipeline_test.exs
+++ b/test/wanderer_notifier/killmail/pipeline_test.exs
@@ -1,5 +1,5 @@
 defmodule WandererNotifier.Domains.Killmail.PipelineTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Mox
 
   alias WandererNotifier.Domains.Killmail.Pipeline

--- a/test/wanderer_notifier/killmail/wanderer_kills_api_test.exs
+++ b/test/wanderer_notifier/killmail/wanderer_kills_api_test.exs
@@ -9,8 +9,21 @@ defmodule WandererNotifier.Killmail.WandererKillsAPITest do
   setup :verify_on_exit!
 
   setup do
+    # Capture original value to restore after test
+    original_http_client = Application.get_env(:wanderer_notifier, :http_client)
+
     # Set up the HTTP client mock
     Application.put_env(:wanderer_notifier, :http_client, HttpClientMock)
+
+    on_exit(fn ->
+      # Restore original value
+      if original_http_client do
+        Application.put_env(:wanderer_notifier, :http_client, original_http_client)
+      else
+        Application.delete_env(:wanderer_notifier, :http_client)
+      end
+    end)
+
     :ok
   end
 

--- a/test/wanderer_notifier/killmail/wanderer_kills_api_test.exs
+++ b/test/wanderer_notifier/killmail/wanderer_kills_api_test.exs
@@ -1,5 +1,5 @@
 defmodule WandererNotifier.Killmail.WandererKillsAPITest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   import Mox
 
   alias WandererNotifier.HTTPMock, as: HttpClientMock


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Rally notifications can mention multiple groups via a configurable list of IDs.
  - Killmail embeds now include a short, deterministic message ID in the footer.
- Bug Fixes
  - Discord delivery: more resilient retries for connection, rate-limit and server errors while avoiding timeout-induced duplicates.
- Tests
  - Many tests now run synchronously; added cache assertion helpers and safer setup/teardown.
- Chores
  - Version bumped to 3.4.0; runtime config accepts multi-source rally group IDs (now a list).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->