### PR TITLE
fix: prune stale systems from reverse index to stop ghost kill notifications

### DIFF
--- a/lib/wanderer_notifier/application/initialization/service_initializer.ex
+++ b/lib/wanderer_notifier/application/initialization/service_initializer.ex
@@ -174,6 +174,10 @@ defmodule WandererNotifier.Application.Initialization.ServiceInitializer do
       # SSE clients for map tracking
       {WandererNotifier.Map.SSESupervisor, []},
 
+      # Hourly reconciliation of the per-map system reverse index against
+      # upstream — safety net for lost SSE delete events
+      {WandererNotifier.Map.Reconciler, []},
+
       # Background schedulers
       {WandererNotifier.Application.Supervisors.Schedulers.Supervisor, []}
     ]

--- a/lib/wanderer_notifier/domains/tracking/entities/system.ex
+++ b/lib/wanderer_notifier/domains/tracking/entities/system.ex
@@ -76,19 +76,29 @@ defmodule WandererNotifier.Domains.Tracking.Entities.System do
   # Extract system ID from various possible keys
   defp extract_system_id(attrs) do
     system_id = attrs["solar_system_id"] || attrs[:solar_system_id] || attrs["id"] || attrs[:id]
-    normalize_system_id(system_id)
+    normalize_solar_system_id(system_id)
   end
 
-  defp normalize_system_id(id) when is_integer(id), do: id
+  @doc """
+  Normalizes a solar system ID to an integer.
 
-  defp normalize_system_id(id) when is_binary(id) do
+  Accepts integers (passed through) or binaries that parse cleanly to an
+  integer. Returns `nil` for anything else — including UUID-style binaries,
+  empty strings, or binaries with trailing garbage. This is intentionally
+  strict so callers on the removal path do not silently operate with
+  non-EVE identifiers as keys.
+  """
+  @spec normalize_solar_system_id(term()) :: integer() | nil
+  def normalize_solar_system_id(id) when is_integer(id), do: id
+
+  def normalize_solar_system_id(id) when is_binary(id) do
     case Integer.parse(id, 10) do
       {int_id, ""} -> int_id
       _ -> nil
     end
   end
 
-  defp normalize_system_id(_), do: nil
+  def normalize_solar_system_id(_), do: nil
 
   # Extract name field (no fallback to :id)
   defp extract_name_field(attrs) do

--- a/lib/wanderer_notifier/domains/tracking/handlers/system_handler.ex
+++ b/lib/wanderer_notifier/domains/tracking/handlers/system_handler.ex
@@ -292,15 +292,25 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandler do
     {:ok, :removed}
   end
 
-  # Resolves a valid EVE solar_system_id from a deleted_system payload. Prefers
-  # the explicit `solar_system_id` field, falls back to `id`. Returns the
-  # integer form or `nil` — nil means the upstream payload did not carry a
-  # parseable EVE system id (e.g. only a map-internal UUID was present), and
-  # the caller MUST NOT attempt to delete/deindex with the raw value, which
-  # could never match the integer keys written by the add path.
+  # Resolves a valid EVE solar_system_id from a deleted_system payload. Tries
+  # each candidate (solar_system_id first, then id; string and atom keys for
+  # parity with the add path) and returns the first one that normalizes
+  # cleanly to an integer. Returns `nil` only when none of the candidates
+  # parse — at that point the caller MUST NOT touch ETS or the cache with
+  # the raw value, because it could never match the integer keys written by
+  # the add path.
+  #
+  # Each candidate is normalized independently so an unparseable-but-truthy
+  # value (e.g. `"solar_system_id" => ""`) does not short-circuit a valid
+  # fallback via Elixir's `||` operator.
   defp extract_solar_system_id(payload) do
-    candidate = Map.get(payload, "solar_system_id") || Map.get(payload, "id")
-    System.normalize_solar_system_id(candidate)
+    [
+      Map.get(payload, "solar_system_id"),
+      Map.get(payload, :solar_system_id),
+      Map.get(payload, "id"),
+      Map.get(payload, :id)
+    ]
+    |> Enum.find_value(&System.normalize_solar_system_id/1)
   end
 
   defp delete_individual_system_cache(map_slug, system_id) do

--- a/lib/wanderer_notifier/domains/tracking/handlers/system_handler.ex
+++ b/lib/wanderer_notifier/domains/tracking/handlers/system_handler.ex
@@ -267,17 +267,28 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandler do
     # GenericEventHandler.remove_from_cache_list/3 always returns {:ok, _}
     {:ok, _} = GenericEventHandler.remove_from_cache_list(:system, payload, map_slug: map_slug)
 
-    if system_id do
-      delete_individual_system_cache(map_slug, system_id)
-      deindex_system_safe(registry, map_slug, system_id)
-    else
-      Logger.warning("Skipping system removal with unresolvable solar_system_id",
-        map_slug: map_slug,
-        payload: inspect(payload, limit: 200),
-        category: :api
-      )
-    end
+    apply_scoped_removal(system_id, payload, map_slug, registry)
+  end
 
+  # Unresolvable solar_system_id — upstream payload carried neither a valid
+  # integer nor a parseable integer-valued binary (e.g. only a map-internal
+  # UUID was present). Operating on the raw value would write bogus ETS and
+  # cache keys that can never match the integer keys written by the add
+  # path. Log and move on; the hourly Reconciler will clean up any resulting
+  # drift.
+  defp apply_scoped_removal(nil, payload, map_slug, _registry) do
+    Logger.warning("Skipping system removal with unresolvable solar_system_id",
+      map_slug: map_slug,
+      payload: inspect(payload, limit: 200),
+      category: :api
+    )
+
+    {:ok, :removed}
+  end
+
+  defp apply_scoped_removal(system_id, _payload, map_slug, registry) do
+    delete_individual_system_cache(map_slug, system_id)
+    deindex_system_safe(registry, map_slug, system_id)
     {:ok, :removed}
   end
 

--- a/lib/wanderer_notifier/domains/tracking/handlers/system_handler.ex
+++ b/lib/wanderer_notifier/domains/tracking/handlers/system_handler.ex
@@ -254,7 +254,7 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandler do
   end
 
   defp handle_system_removal(payload, map_slug, registry) do
-    system_id = Map.get(payload, "solar_system_id") || Map.get(payload, "id")
+    system_id = extract_solar_system_id(payload)
 
     Logger.debug("Removing system from cache",
       solar_system_id: Map.get(payload, "solar_system_id"),
@@ -267,42 +267,54 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandler do
     # GenericEventHandler.remove_from_cache_list/3 always returns {:ok, _}
     {:ok, _} = GenericEventHandler.remove_from_cache_list(:system, payload, map_slug: map_slug)
 
-    # Also remove individual system cache entry (map-scoped)
     if system_id do
-      system_id
-      |> to_string()
-      |> then(&Cache.Keys.tracked_system(map_slug, &1))
-      |> Cache.delete()
-    end
-
-    # Update reverse index for killmail fan-out (best-effort)
-    if system_id do
-      try do
-        case registry.deindex_system(map_slug, system_id) do
-          :ok ->
-            :ok
-
-          {:ok, _} ->
-            :ok
-
-          {:error, reason} ->
-            Logger.error("Failed to deindex system from reverse index",
-              map_slug: map_slug,
-              system_id: system_id,
-              reason: inspect(reason)
-            )
-        end
-      rescue
-        e ->
-          Logger.error("Failed to deindex system from reverse index",
-            map_slug: map_slug,
-            system_id: system_id,
-            reason: Exception.message(e)
-          )
-      end
+      delete_individual_system_cache(map_slug, system_id)
+      deindex_system_safe(registry, map_slug, system_id)
+    else
+      Logger.warning("Skipping system removal with unresolvable solar_system_id",
+        map_slug: map_slug,
+        payload: inspect(payload, limit: 200),
+        category: :api
+      )
     end
 
     {:ok, :removed}
+  end
+
+  # Resolves a valid EVE solar_system_id from a deleted_system payload. Prefers
+  # the explicit `solar_system_id` field, falls back to `id`. Returns the
+  # integer form or `nil` — nil means the upstream payload did not carry a
+  # parseable EVE system id (e.g. only a map-internal UUID was present), and
+  # the caller MUST NOT attempt to delete/deindex with the raw value, which
+  # could never match the integer keys written by the add path.
+  defp extract_solar_system_id(payload) do
+    candidate = Map.get(payload, "solar_system_id") || Map.get(payload, "id")
+    System.normalize_solar_system_id(candidate)
+  end
+
+  defp delete_individual_system_cache(map_slug, system_id) do
+    system_id
+    |> to_string()
+    |> then(&Cache.Keys.tracked_system(map_slug, &1))
+    |> Cache.delete()
+  end
+
+  defp deindex_system_safe(registry, map_slug, system_id) do
+    case registry.deindex_system(map_slug, system_id) do
+      :ok -> :ok
+      {:ok, _} -> :ok
+      {:error, reason} -> log_deindex_error(map_slug, system_id, reason)
+    end
+  rescue
+    e -> log_deindex_error(map_slug, system_id, Exception.message(e))
+  end
+
+  defp log_deindex_error(map_slug, system_id, reason) do
+    Logger.error("Failed to deindex system from reverse index",
+      map_slug: map_slug,
+      system_id: system_id,
+      reason: inspect(reason)
+    )
   end
 
   defp system_matches?(%System{solar_system_id: sid}, system_id), do: sid == system_id

--- a/lib/wanderer_notifier/map/map_registry.ex
+++ b/lib/wanderer_notifier/map/map_registry.ex
@@ -159,6 +159,22 @@ defmodule WandererNotifier.Map.MapRegistry do
   end
 
   @doc """
+  Returns all system_id strings currently indexed for a specific map slug.
+
+  Used by the reconciler to compute which systems are stale (indexed for the
+  slug but no longer present in the upstream map data). O(n) over the system
+  index table; acceptable given the hourly reconcile cadence.
+  """
+  @spec systems_for_map(String.t()) :: [String.t()]
+  def systems_for_map(map_slug) when is_binary(map_slug) do
+    @system_index_table
+    |> :ets.match_object({:"$1", map_slug})
+    |> Enum.map(fn {system_key, _slug} -> system_key end)
+  rescue
+    ArgumentError -> []
+  end
+
+  @doc """
   Returns map configs that track a given character ID.
 
   Uses the reverse index for O(1) lookup. Returns an empty list

--- a/lib/wanderer_notifier/map/map_registry_behaviour.ex
+++ b/lib/wanderer_notifier/map/map_registry_behaviour.ex
@@ -11,4 +11,9 @@ defmodule WandererNotifier.Map.MapRegistryBehaviour do
   @callback maps_tracking_system(String.t() | integer()) :: [term()]
   @callback maps_tracking_character(String.t() | integer()) :: [term()]
   @callback all_maps() :: [term()]
+  @callback index_system(String.t(), String.t() | integer()) :: :ok
+  @callback deindex_system(String.t(), String.t() | integer()) :: :ok
+  @callback index_character(String.t(), String.t() | integer()) :: :ok
+  @callback deindex_character(String.t(), String.t() | integer()) :: :ok
+  @callback systems_for_map(String.t()) :: [String.t()]
 end

--- a/lib/wanderer_notifier/map/reconciler.ex
+++ b/lib/wanderer_notifier/map/reconciler.ex
@@ -96,7 +96,7 @@ defmodule WandererNotifier.Map.Reconciler do
   end
 
   defp empty_summary do
-    %{reconciled: 0, empty: 0, error: 0, crash: 0}
+    %{reconciled: 0, empty: 0, malformed: 0, error: 0, crash: 0}
   end
 
   defp aggregate_task_result({:ok, {:ok, :reconciled}}, acc),
@@ -105,20 +105,27 @@ defmodule WandererNotifier.Map.Reconciler do
   defp aggregate_task_result({:ok, {:ok, :skipped_empty}}, acc),
     do: %{acc | empty: acc.empty + 1}
 
+  defp aggregate_task_result({:ok, {:ok, :skipped_malformed}}, acc),
+    do: %{acc | malformed: acc.malformed + 1}
+
   defp aggregate_task_result({:ok, {:error, _reason}}, acc),
     do: %{acc | error: acc.error + 1}
 
   defp aggregate_task_result({:exit, _reason}, acc),
     do: %{acc | crash: acc.crash + 1}
 
-  defp log_summary(%{reconciled: rec, empty: emp, error: err, crash: crash}, total, elapsed_ms) do
+  defp log_summary(summary, total, elapsed_ms) do
+    %{reconciled: rec, empty: emp, malformed: mal, error: err, crash: crash} = summary
+
     Logger.info(
       "Reconciler tick complete: #{rec}/#{total} reconciled, " <>
-        "#{emp} empty (skipped), #{err} errors (skipped), #{crash} crashes",
+        "#{emp} empty (skipped), #{mal} malformed (skipped), " <>
+        "#{err} errors (skipped), #{crash} crashes",
       category: :reconcile,
       total: total,
       reconciled: rec,
       empty: emp,
+      malformed: mal,
       error: err,
       crash: crash,
       elapsed_ms: elapsed_ms
@@ -160,8 +167,7 @@ defmodule WandererNotifier.Map.Reconciler do
         {:ok, :skipped_empty}
 
       {:ok, fresh_systems} when is_list(fresh_systems) ->
-        prune_stale_systems(map_config, registry, fresh_systems)
-        {:ok, :reconciled}
+        handle_fresh_systems(map_config, registry, fresh_systems)
 
       {:error, reason} ->
         Logger.warning("Reconciler: fetch failed, leaving state unchanged",
@@ -171,6 +177,30 @@ defmodule WandererNotifier.Map.Reconciler do
         )
 
         {:error, reason}
+    end
+  end
+
+  # Computes the fresh id set once and gates on whether it yielded anything
+  # useful. A non-empty upstream list whose entries all fail normalization
+  # (e.g. a schema change, a proxy serving corrupted JSON) would otherwise
+  # be treated as "the map tracks nothing" and wipe the entire reverse
+  # index — exactly the clobber scenario the reconciler must not cause.
+  defp handle_fresh_systems(map_config, registry, fresh_systems) do
+    fresh_id_set = build_fresh_id_set(fresh_systems)
+
+    if MapSet.size(fresh_id_set) == 0 do
+      Logger.warning(
+        "Reconciler: upstream returned list with no parseable system ids — " <>
+          "treating as malformed, leaving state unchanged",
+        map_slug: map_config.slug,
+        upstream_count: length(fresh_systems),
+        category: :reconcile
+      )
+
+      {:ok, :skipped_malformed}
+    else
+      prune_stale_systems(map_config, registry, fresh_id_set)
+      {:ok, :reconciled}
     end
   end
 
@@ -231,10 +261,9 @@ defmodule WandererNotifier.Map.Reconciler do
       {:error, {:exception, Exception.message(e)}}
   end
 
-  defp prune_stale_systems(%MapConfig{slug: slug}, registry, fresh_systems) do
-    fresh_ids = build_fresh_id_set(fresh_systems)
+  defp prune_stale_systems(%MapConfig{slug: slug}, registry, fresh_id_set) do
     current_ids = slug |> registry.systems_for_map() |> MapSet.new()
-    stale_ids = MapSet.difference(current_ids, fresh_ids)
+    stale_ids = MapSet.difference(current_ids, fresh_id_set)
     stale_count = MapSet.size(stale_ids)
 
     if stale_count > 0 do
@@ -242,14 +271,38 @@ defmodule WandererNotifier.Map.Reconciler do
         map_slug: slug,
         stale_count: stale_count,
         current_count: MapSet.size(current_ids),
-        fresh_count: MapSet.size(fresh_ids),
+        fresh_count: MapSet.size(fresh_id_set),
         category: :reconcile
       )
     end
 
-    Enum.each(stale_ids, fn stale_id ->
-      registry.deindex_system(slug, stale_id)
-    end)
+    Enum.each(stale_ids, &deindex_one_safe(registry, slug, &1))
+  end
+
+  # Defensive deindex wrapper. The real MapRegistry.deindex_system/2 always
+  # returns `:ok`, but a mock or alternate implementation could surface an
+  # error or raise. We log and continue rather than short-circuit, because
+  # aborting mid-loop would leave partial state worse than the best-effort
+  # end state (stale ids after the failure point would remain stale *and*
+  # we'd lose the signal that some ids were successfully pruned).
+  defp deindex_one_safe(registry, slug, system_id) do
+    case registry.deindex_system(slug, system_id) do
+      :ok -> :ok
+      {:ok, _} -> :ok
+      {:error, reason} -> log_deindex_failure(slug, system_id, reason)
+    end
+  rescue
+    e -> log_deindex_failure(slug, system_id, Exception.message(e))
+  end
+
+  defp log_deindex_failure(slug, system_id, reason) do
+    Logger.warning(
+      "Reconciler: failed to deindex stale system — continuing with remaining ids",
+      map_slug: slug,
+      system_id: system_id,
+      reason: inspect(reason),
+      category: :reconcile
+    )
   end
 
   # Builds a MapSet of normalized system_id strings. Entries whose id cannot
@@ -265,12 +318,19 @@ defmodule WandererNotifier.Map.Reconciler do
     end)
   end
 
+  # Normalizes each candidate independently so an unparseable-but-truthy
+  # value (e.g. `"solar_system_id" => ""`) does not short-circuit a valid
+  # fallback via Elixir's `||` operator. Same fix pattern as
+  # SystemHandler.extract_solar_system_id/1.
   defp normalize_fresh_system_id(system) when is_map(system) do
-    raw =
-      system["solar_system_id"] || system[:solar_system_id] ||
-        system["id"] || system[:id]
-
-    case SystemEntity.normalize_solar_system_id(raw) do
+    [
+      Map.get(system, "solar_system_id"),
+      Map.get(system, :solar_system_id),
+      Map.get(system, "id"),
+      Map.get(system, :id)
+    ]
+    |> Enum.find_value(&SystemEntity.normalize_solar_system_id/1)
+    |> case do
       nil -> nil
       int_id -> Integer.to_string(int_id)
     end

--- a/lib/wanderer_notifier/map/reconciler.ex
+++ b/lib/wanderer_notifier/map/reconciler.ex
@@ -1,0 +1,253 @@
+defmodule WandererNotifier.Map.Reconciler do
+  @moduledoc """
+  Periodically reconciles the per-map system tracking state against upstream.
+
+  ## Why this exists
+
+  The MapRegistry reverse index (`system_id -> [map_slugs]`) is the single
+  source of truth for killmail notification fan-out. It is maintained in two
+  places:
+
+    * Initial population at startup via `MapTrackingClient.fetch_and_cache_systems/2`
+    * Delta maintenance via SSE `add_system` / `deleted_system` events
+
+  If an SSE event is lost — e.g. a client dies silently during a long uptime
+  (see commit cfe85c5c), a reconnect window drops an event, or the upstream
+  misses a delete — the reverse index becomes permanently stale and the
+  pipeline keeps fanning killmail notifications out to maps that no longer
+  track the system. Users see "ghost" kill notifications for systems that
+  were removed from their map, sometimes more than a day after removal.
+
+  This reconciler closes that gap by re-fetching the authoritative system
+  list from the map API every hour and pruning any reverse-index entries
+  that are no longer present upstream. It is intentionally a safety net, not
+  a replacement for SSE delta events — those remain the fast path.
+
+  ## Safety properties
+
+    * **First run is delayed.** The first reconcile is scheduled one full
+      interval after start, so initialization via `Map.Initializer` is always
+      fully effective before reconcile runs.
+    * **Empty responses never clobber state.** If the upstream returns an
+      empty list for any reason (transient bug, caching proxy returning stale
+      200s, etc.) the reconcile is skipped for that map and existing state
+      is preserved. A warning is logged.
+    * **Errors never clobber state.** If the upstream returns an error
+      (timeout, 5xx, connection refused) the reconcile is skipped for that
+      map and existing state is preserved. A warning is logged.
+    * **Per-map isolation.** Reconciles run under `Task.async_stream` with a
+      concurrency cap; a failure on one map does not affect any other.
+    * **Systems-only.** Character tracking is not reconciled — character
+      rosters rarely change, and doing both in the same pass would double
+      API traffic without a corresponding payoff.
+  """
+
+  use GenServer
+  require Logger
+
+  alias WandererNotifier.Domains.Tracking.Entities.System
+  alias WandererNotifier.Map.MapConfig
+  alias WandererNotifier.Shared.Dependencies
+
+  @reconcile_interval :timer.hours(1)
+  @max_concurrency 5
+  @task_timeout :timer.seconds(30)
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # Public API
+  # ════════════════════════════════════════════════════════════════════════════
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Reconciles the system reverse index for every currently registered map.
+
+  Exposed publicly so operators can trigger a manual reconcile from IEx if
+  they suspect staleness (`WandererNotifier.Map.Reconciler.reconcile_all/0`).
+  """
+  @spec reconcile_all() :: :ok
+  def reconcile_all do
+    registry = Dependencies.map_registry()
+    fetch_fun = &default_fetch/1
+
+    registry.all_maps()
+    |> Task.async_stream(
+      fn map_config -> safe_reconcile(map_config, registry, fetch_fun) end,
+      max_concurrency: @max_concurrency,
+      timeout: @task_timeout,
+      on_timeout: :kill_task
+    )
+    |> Stream.run()
+
+    :ok
+  end
+
+  @doc """
+  Reconciles the system reverse index for a single map.
+
+  ## Options
+
+    * `:registry` - module implementing `MapRegistryBehaviour`. Defaults to
+      `Dependencies.map_registry()`.
+    * `:fetch_fun` - 1-arity function that takes a `MapConfig.t()` and
+      returns `{:ok, [map()]}` or `{:error, term()}`. Defaults to a wrapper
+      around `Dependencies.map_tracking_client().fetch_and_cache_systems/2`.
+
+  ## Returns
+
+    * `{:ok, :reconciled}` - fetch succeeded, diff was applied.
+    * `{:ok, :skipped_empty}` - upstream returned an empty list; state
+      intentionally left unchanged.
+    * `{:error, reason}` - upstream fetch failed; state intentionally left
+      unchanged.
+  """
+  @spec reconcile_map(MapConfig.t(), keyword()) ::
+          {:ok, :reconciled | :skipped_empty} | {:error, term()}
+  def reconcile_map(%MapConfig{} = map_config, opts \\ []) do
+    registry = Keyword.get(opts, :registry, Dependencies.map_registry())
+    fetch_fun = Keyword.get(opts, :fetch_fun, &default_fetch/1)
+
+    case fetch_fun.(map_config) do
+      {:ok, []} ->
+        Logger.warning("Reconciler: empty system list, leaving state unchanged",
+          map_slug: map_config.slug,
+          category: :reconcile
+        )
+
+        {:ok, :skipped_empty}
+
+      {:ok, fresh_systems} when is_list(fresh_systems) ->
+        prune_stale_systems(map_config, registry, fresh_systems)
+        {:ok, :reconciled}
+
+      {:error, reason} ->
+        Logger.warning("Reconciler: fetch failed, leaving state unchanged",
+          map_slug: map_config.slug,
+          reason: inspect(reason),
+          category: :reconcile
+        )
+
+        {:error, reason}
+    end
+  end
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # GenServer callbacks
+  # ════════════════════════════════════════════════════════════════════════════
+
+  @impl GenServer
+  def init(_opts) do
+    Logger.info("Map reconciler starting — first tick in #{interval_label()}",
+      interval_ms: @reconcile_interval,
+      category: :startup
+    )
+
+    {:ok, %{timer: schedule_reconcile()}}
+  end
+
+  @impl GenServer
+  def handle_info(:reconcile, state) do
+    do_reconcile()
+    {:noreply, %{state | timer: schedule_reconcile()}}
+  end
+
+  # Catch-all for unexpected messages (mirrors SSEClient pattern from cfe85c5c)
+  @impl GenServer
+  def handle_info(msg, state) do
+    Logger.warning("Map reconciler received unhandled message",
+      message: inspect(msg, limit: 200)
+    )
+
+    {:noreply, state}
+  end
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # Private
+  # ════════════════════════════════════════════════════════════════════════════
+
+  defp do_reconcile do
+    reconcile_all()
+  rescue
+    e ->
+      Logger.error("Map reconciler tick crashed — state preserved",
+        reason: Exception.message(e),
+        stacktrace: Exception.format_stacktrace(__STACKTRACE__)
+      )
+  end
+
+  defp safe_reconcile(map_config, registry, fetch_fun) do
+    reconcile_map(map_config, registry: registry, fetch_fun: fetch_fun)
+  rescue
+    e ->
+      Logger.error("Reconciler: exception while reconciling map",
+        map_slug: map_config.slug,
+        reason: Exception.message(e),
+        category: :reconcile
+      )
+
+      {:error, {:exception, Exception.message(e)}}
+  end
+
+  defp prune_stale_systems(%MapConfig{slug: slug}, registry, fresh_systems) do
+    fresh_ids = build_fresh_id_set(fresh_systems)
+    current_ids = slug |> registry.systems_for_map() |> MapSet.new()
+    stale_ids = MapSet.difference(current_ids, fresh_ids)
+    stale_count = MapSet.size(stale_ids)
+
+    if stale_count > 0 do
+      Logger.info("Reconciler: pruning stale systems from reverse index",
+        map_slug: slug,
+        stale_count: stale_count,
+        current_count: MapSet.size(current_ids),
+        fresh_count: MapSet.size(fresh_ids),
+        category: :reconcile
+      )
+    end
+
+    Enum.each(stale_ids, fn stale_id ->
+      registry.deindex_system(slug, stale_id)
+    end)
+  end
+
+  # Builds a MapSet of normalized system_id strings. Entries whose id cannot
+  # be normalized to an integer are silently dropped — they cannot match the
+  # reverse index anyway and including them would poison the diff.
+  defp build_fresh_id_set(fresh_systems) do
+    fresh_systems
+    |> Enum.reduce(MapSet.new(), fn system, acc ->
+      case normalize_fresh_system_id(system) do
+        nil -> acc
+        id -> MapSet.put(acc, id)
+      end
+    end)
+  end
+
+  defp normalize_fresh_system_id(system) when is_map(system) do
+    raw =
+      system["solar_system_id"] || system[:solar_system_id] ||
+        system["id"] || system[:id]
+
+    case System.normalize_solar_system_id(raw) do
+      nil -> nil
+      int_id -> Integer.to_string(int_id)
+    end
+  end
+
+  defp normalize_fresh_system_id(_), do: nil
+
+  defp default_fetch(%MapConfig{} = map_config) do
+    Dependencies.map_tracking_client().fetch_and_cache_systems(map_config, true)
+  end
+
+  defp schedule_reconcile do
+    Process.send_after(self(), :reconcile, @reconcile_interval)
+  end
+
+  defp interval_label do
+    minutes = div(@reconcile_interval, 60_000)
+    "#{minutes} minute(s)"
+  end
+end

--- a/lib/wanderer_notifier/map/reconciler.ex
+++ b/lib/wanderer_notifier/map/reconciler.ex
@@ -45,7 +45,7 @@ defmodule WandererNotifier.Map.Reconciler do
   use GenServer
   require Logger
 
-  alias WandererNotifier.Domains.Tracking.Entities.System
+  alias WandererNotifier.Domains.Tracking.Entities.System, as: SystemEntity
   alias WandererNotifier.Map.MapConfig
   alias WandererNotifier.Shared.Dependencies
 
@@ -67,22 +67,62 @@ defmodule WandererNotifier.Map.Reconciler do
 
   Exposed publicly so operators can trigger a manual reconcile from IEx if
   they suspect staleness (`WandererNotifier.Map.Reconciler.reconcile_all/0`).
+
+  Accepts the same `:registry` and `:fetch_fun` options as `reconcile_map/2`
+  to make the full-tick path testable without touching application env.
   """
-  @spec reconcile_all() :: :ok
-  def reconcile_all do
-    registry = Dependencies.map_registry()
-    fetch_fun = &default_fetch/1
+  @spec reconcile_all(keyword()) :: :ok
+  def reconcile_all(opts \\ []) do
+    registry = Keyword.get(opts, :registry, Dependencies.map_registry())
+    fetch_fun = Keyword.get(opts, :fetch_fun, &default_fetch/1)
 
-    registry.all_maps()
-    |> Task.async_stream(
-      fn map_config -> safe_reconcile(map_config, registry, fetch_fun) end,
-      max_concurrency: @max_concurrency,
-      timeout: @task_timeout,
-      on_timeout: :kill_task
-    )
-    |> Stream.run()
+    maps = registry.all_maps()
+    total = length(maps)
+    start_ms = System.monotonic_time(:millisecond)
 
+    summary =
+      maps
+      |> Task.async_stream(
+        fn map_config -> safe_reconcile(map_config, registry, fetch_fun) end,
+        max_concurrency: @max_concurrency,
+        timeout: @task_timeout,
+        on_timeout: :kill_task
+      )
+      |> Enum.reduce(empty_summary(), &aggregate_task_result/2)
+
+    elapsed_ms = System.monotonic_time(:millisecond) - start_ms
+    log_summary(summary, total, elapsed_ms)
     :ok
+  end
+
+  defp empty_summary do
+    %{reconciled: 0, empty: 0, error: 0, crash: 0}
+  end
+
+  defp aggregate_task_result({:ok, {:ok, :reconciled}}, acc),
+    do: %{acc | reconciled: acc.reconciled + 1}
+
+  defp aggregate_task_result({:ok, {:ok, :skipped_empty}}, acc),
+    do: %{acc | empty: acc.empty + 1}
+
+  defp aggregate_task_result({:ok, {:error, _reason}}, acc),
+    do: %{acc | error: acc.error + 1}
+
+  defp aggregate_task_result({:exit, _reason}, acc),
+    do: %{acc | crash: acc.crash + 1}
+
+  defp log_summary(%{reconciled: rec, empty: emp, error: err, crash: crash}, total, elapsed_ms) do
+    Logger.info(
+      "Reconciler tick complete: #{rec}/#{total} reconciled, " <>
+        "#{emp} empty (skipped), #{err} errors (skipped), #{crash} crashes",
+      category: :reconcile,
+      total: total,
+      reconciled: rec,
+      empty: emp,
+      error: err,
+      crash: crash,
+      elapsed_ms: elapsed_ms
+    )
   end
 
   @doc """
@@ -230,7 +270,7 @@ defmodule WandererNotifier.Map.Reconciler do
       system["solar_system_id"] || system[:solar_system_id] ||
         system["id"] || system[:id]
 
-    case System.normalize_solar_system_id(raw) do
+    case SystemEntity.normalize_solar_system_id(raw) do
       nil -> nil
       int_id -> Integer.to_string(int_id)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule WandererNotifier.MixProject do
   def project do
     [
       app: :wanderer_notifier,
-      version: "6.1.0",
+      version: "6.1.1",
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/wanderer_notifier/domains/tracking/entities/system_test.exs
+++ b/test/wanderer_notifier/domains/tracking/entities/system_test.exs
@@ -85,6 +85,32 @@ defmodule WandererNotifier.Domains.Tracking.Entities.SystemTest do
     end
   end
 
+  describe "normalize_solar_system_id/1" do
+    test "returns integer as-is" do
+      assert System.normalize_solar_system_id(30_000_142) == 30_000_142
+    end
+
+    test "parses integer-valued binary" do
+      assert System.normalize_solar_system_id("30000142") == 30_000_142
+    end
+
+    test "returns nil for non-integer binary (UUID)" do
+      assert System.normalize_solar_system_id("map-uuid-abc123") == nil
+    end
+
+    test "returns nil for empty binary" do
+      assert System.normalize_solar_system_id("") == nil
+    end
+
+    test "returns nil for nil" do
+      assert System.normalize_solar_system_id(nil) == nil
+    end
+
+    test "returns nil for binary with trailing garbage" do
+      assert System.normalize_solar_system_id("30000142-suffix") == nil
+    end
+  end
+
   describe "wormhole?/1" do
     test "returns true for wormhole systems with string type" do
       system =

--- a/test/wanderer_notifier/domains/tracking/handlers/system_handler_test.exs
+++ b/test/wanderer_notifier/domains/tracking/handlers/system_handler_test.exs
@@ -333,6 +333,44 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandlerTest do
       refute_received {:deindex_called, @map_slug, "map-uuid-abc123"}
     end
 
+    test "falls through blank solar_system_id to a valid id fallback" do
+      test_pid = self()
+      mock = WandererNotifier.MockMapRegistry
+
+      stub(mock, :index_system, fn _slug, _id -> :ok end)
+
+      stub(mock, :deindex_system, fn map_slug, system_id ->
+        send(test_pid, {:deindex_called, map_slug, system_id})
+        :ok
+      end)
+
+      original = Application.get_env(:wanderer_notifier, :map_registry_module)
+      Application.put_env(:wanderer_notifier, :map_registry_module, mock)
+
+      on_exit(fn ->
+        if original do
+          Application.put_env(:wanderer_notifier, :map_registry_module, original)
+        else
+          Application.delete_env(:wanderer_notifier, :map_registry_module)
+        end
+      end)
+
+      # Blank solar_system_id (truthy, so a naive `||` short-circuits and
+      # never consults the valid `id` fallback) — the fix must normalize
+      # each candidate separately and pick the first non-nil.
+      event = %{
+        "type" => "deleted_system",
+        "payload" => %{
+          "solar_system_id" => "",
+          "id" => 31_000_001
+        }
+      }
+
+      assert :ok = SystemHandler.handle_entity_removed(event, @map_slug)
+
+      assert_received {:deindex_called, @map_slug, 31_000_001}
+    end
+
     test "skips deindex and warns when payload has only an unparseable id" do
       test_pid = self()
       mock = WandererNotifier.MockMapRegistry

--- a/test/wanderer_notifier/domains/tracking/handlers/system_handler_test.exs
+++ b/test/wanderer_notifier/domains/tracking/handlers/system_handler_test.exs
@@ -295,6 +295,83 @@ defmodule WandererNotifier.Domains.Tracking.Handlers.SystemHandlerTest do
       assert Enum.empty?(updated_systems)
       assert {:error, :not_found} = Cache.get_tracked_system(@map_slug, "31000001")
     end
+
+    test "deindexes with normalized integer solar_system_id, not UUID id" do
+      test_pid = self()
+      mock = WandererNotifier.MockMapRegistry
+
+      stub(mock, :index_system, fn _slug, _id -> :ok end)
+
+      stub(mock, :deindex_system, fn map_slug, system_id ->
+        send(test_pid, {:deindex_called, map_slug, system_id})
+        :ok
+      end)
+
+      original = Application.get_env(:wanderer_notifier, :map_registry_module)
+      Application.put_env(:wanderer_notifier, :map_registry_module, mock)
+
+      on_exit(fn ->
+        if original do
+          Application.put_env(:wanderer_notifier, :map_registry_module, original)
+        else
+          Application.delete_env(:wanderer_notifier, :map_registry_module)
+        end
+      end)
+
+      event = %{
+        "type" => "deleted_system",
+        "payload" => %{
+          "id" => "map-uuid-abc123",
+          "solar_system_id" => 31_000_001
+        }
+      }
+
+      assert :ok = SystemHandler.handle_entity_removed(event, @map_slug)
+
+      # Key sent to deindex must be the normalized integer, NOT the UUID
+      assert_received {:deindex_called, @map_slug, 31_000_001}
+      refute_received {:deindex_called, @map_slug, "map-uuid-abc123"}
+    end
+
+    test "skips deindex and warns when payload has only an unparseable id" do
+      test_pid = self()
+      mock = WandererNotifier.MockMapRegistry
+
+      stub(mock, :index_system, fn _slug, _id -> :ok end)
+
+      stub(mock, :deindex_system, fn map_slug, system_id ->
+        send(test_pid, {:deindex_called, map_slug, system_id})
+        :ok
+      end)
+
+      original = Application.get_env(:wanderer_notifier, :map_registry_module)
+      Application.put_env(:wanderer_notifier, :map_registry_module, mock)
+
+      on_exit(fn ->
+        if original do
+          Application.put_env(:wanderer_notifier, :map_registry_module, original)
+        else
+          Application.delete_env(:wanderer_notifier, :map_registry_module)
+        end
+      end)
+
+      event = %{
+        "type" => "deleted_system",
+        "payload" => %{
+          "id" => "map-uuid-abc123"
+        }
+      }
+
+      log =
+        capture_log(fn ->
+          assert :ok = SystemHandler.handle_entity_removed(event, @map_slug)
+        end)
+
+      # No deindex should have been attempted — the UUID is not a valid EVE system id
+      refute_received {:deindex_called, _, _}
+      # Should have logged a warning so the bad upstream payload is visible
+      assert log =~ "unresolvable solar_system_id"
+    end
   end
 
   describe "handle_entity_added/2" do

--- a/test/wanderer_notifier/map/map_registry_test.exs
+++ b/test/wanderer_notifier/map/map_registry_test.exs
@@ -78,4 +78,36 @@ defmodule WandererNotifier.Map.MapRegistryTest do
       :persistent_term.put({MapRegistry, :mode}, :api)
     end
   end
+
+  describe "systems_for_map/1" do
+    test "returns empty list for a slug with no indexed systems" do
+      assert MapRegistry.systems_for_map("empty-map") == []
+    end
+
+    test "returns indexed system ids for a specific slug" do
+      :ets.insert(@system_index_table, {"31000001", "map-a"})
+      :ets.insert(@system_index_table, {"31000002", "map-a"})
+      :ets.insert(@system_index_table, {"31000003", "map-b"})
+
+      result = MapRegistry.systems_for_map("map-a")
+
+      assert Enum.sort(result) == ["31000001", "31000002"]
+    end
+
+    test "does not include systems indexed for other slugs only" do
+      :ets.insert(@system_index_table, {"31000001", "map-a"})
+      :ets.insert(@system_index_table, {"31000002", "map-b"})
+
+      assert MapRegistry.systems_for_map("map-a") == ["31000001"]
+      assert MapRegistry.systems_for_map("map-b") == ["31000002"]
+    end
+
+    test "includes a system shared across multiple maps" do
+      :ets.insert(@system_index_table, {"31000001", "map-a"})
+      :ets.insert(@system_index_table, {"31000001", "map-b"})
+
+      assert MapRegistry.systems_for_map("map-a") == ["31000001"]
+      assert MapRegistry.systems_for_map("map-b") == ["31000001"]
+    end
+  end
 end

--- a/test/wanderer_notifier/map/reconciler_test.exs
+++ b/test/wanderer_notifier/map/reconciler_test.exs
@@ -154,6 +154,40 @@ defmodule WandererNotifier.Map.ReconcilerTest do
       assert_received {:deindex, @map_slug, "31000002"}
     end
 
+    test "reconcile_all logs a summary aggregating per-map outcomes" do
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      map_a = %MapConfig{slug: "map-a", name: "A", map_id: "a"}
+      map_b = %MapConfig{slug: "map-b", name: "B", map_id: "b"}
+      map_c = %MapConfig{slug: "map-c", name: "C", map_id: "c"}
+
+      stub(mock_registry, :all_maps, fn -> [map_a, map_b, map_c] end)
+      stub(mock_registry, :systems_for_map, fn _slug -> [] end)
+      stub(mock_registry, :deindex_system, fn _slug, _id -> :ok end)
+
+      # One happy path, one empty upstream, one error
+      fetch_fun = fn
+        %MapConfig{slug: "map-a"} -> {:ok, [%{"solar_system_id" => 31_000_001}]}
+        %MapConfig{slug: "map-b"} -> {:ok, []}
+        %MapConfig{slug: "map-c"} -> {:error, :timeout}
+      end
+
+      log =
+        capture_log(fn ->
+          assert :ok =
+                   Reconciler.reconcile_all(
+                     registry: mock_registry,
+                     fetch_fun: fetch_fun
+                   )
+        end)
+
+      assert log =~ "Reconciler tick complete"
+      assert log =~ "1/3 reconciled"
+      assert log =~ "1 empty"
+      assert log =~ "1 errors"
+      assert log =~ "0 crashes"
+    end
+
     test "ignores fresh systems without a parseable solar_system_id" do
       test_pid = self()
       mock_registry = WandererNotifier.MockMapRegistry

--- a/test/wanderer_notifier/map/reconciler_test.exs
+++ b/test/wanderer_notifier/map/reconciler_test.exs
@@ -188,6 +188,109 @@ defmodule WandererNotifier.Map.ReconcilerTest do
       assert log =~ "0 crashes"
     end
 
+    test "treats non-empty list with no parseable ids as malformed and leaves state unchanged" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      stub(mock_registry, :systems_for_map, fn _slug -> ["31000001", "31000002"] end)
+
+      stub(mock_registry, :deindex_system, fn slug, system_id ->
+        send(test_pid, {:deindex, slug, system_id})
+        :ok
+      end)
+
+      # Upstream returns a non-empty list where every entry fails to
+      # normalize — e.g., a schema change or a caching proxy serving a
+      # corrupted payload. Treat as malformed; do not prune.
+      fetch_fun = fn _map_config ->
+        {:ok,
+         [
+           %{"name" => "No ids at all"},
+           %{"garbage" => true},
+           %{"solar_system_id" => "not-a-number"}
+         ]}
+      end
+
+      log =
+        capture_log(fn ->
+          assert {:ok, :skipped_malformed} =
+                   Reconciler.reconcile_map(build_map_config(),
+                     registry: mock_registry,
+                     fetch_fun: fetch_fun
+                   )
+        end)
+
+      refute_received {:deindex, _, _}
+      assert log =~ "no parseable system ids"
+    end
+
+    test "falls through blank solar_system_id to id when building fresh set" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      stub(mock_registry, :systems_for_map, fn _slug -> ["31000001", "31000002"] end)
+
+      stub(mock_registry, :deindex_system, fn slug, system_id ->
+        send(test_pid, {:deindex, slug, system_id})
+        :ok
+      end)
+
+      # Blank solar_system_id (truthy, short-circuits naive `||`) — the
+      # build_fresh_id_set normalization must consult the id fallback too.
+      fetch_fun = fn _map_config ->
+        {:ok, [%{"solar_system_id" => "", "id" => 31_000_001}]}
+      end
+
+      assert {:ok, :reconciled} =
+               Reconciler.reconcile_map(build_map_config(),
+                 registry: mock_registry,
+                 fetch_fun: fetch_fun
+               )
+
+      # 31000001 is still present (via the id fallback) — must not be deindexed
+      refute_received {:deindex, @map_slug, "31000001"}
+      # 31000002 is stale and must be deindexed
+      assert_received {:deindex, @map_slug, "31000002"}
+    end
+
+    test "logs and continues when deindex returns an error for one id" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      stub(mock_registry, :systems_for_map, fn _slug -> ["31000001", "31000002"] end)
+
+      # One deindex errors, the other succeeds — the reconciler must still
+      # attempt every stale id and not abort midway.
+      stub(mock_registry, :deindex_system, fn slug, system_id ->
+        case system_id do
+          "31000001" ->
+            send(test_pid, {:deindex_error, slug, system_id})
+            {:error, :boom}
+
+          _ ->
+            send(test_pid, {:deindex_ok, slug, system_id})
+            :ok
+        end
+      end)
+
+      # Fresh upstream says nothing is tracked — both current ids are stale
+      fetch_fun = fn _map_config -> {:ok, [%{"solar_system_id" => 99_999_999}]} end
+
+      log =
+        capture_log(fn ->
+          # Still :reconciled — partial-failure is logged, not rolled back.
+          # Rolling back would leave us with worse state than best-effort
+          # progression, because deindex already succeeded for 31000002.
+          assert {:ok, :reconciled} =
+                   Reconciler.reconcile_map(build_map_config(),
+                     registry: mock_registry,
+                     fetch_fun: fetch_fun
+                   )
+        end)
+
+      assert log =~ "failed to deindex stale system"
+    end
+
     test "ignores fresh systems without a parseable solar_system_id" do
       test_pid = self()
       mock_registry = WandererNotifier.MockMapRegistry

--- a/test/wanderer_notifier/map/reconciler_test.exs
+++ b/test/wanderer_notifier/map/reconciler_test.exs
@@ -1,0 +1,187 @@
+defmodule WandererNotifier.Map.ReconcilerTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+  import Mox
+
+  alias WandererNotifier.Map.MapConfig
+  alias WandererNotifier.Map.Reconciler
+
+  setup :verify_on_exit!
+
+  @map_slug "test-slug"
+
+  defp build_map_config do
+    %MapConfig{
+      slug: @map_slug,
+      name: "Test Map",
+      map_id: "test-map-id"
+    }
+  end
+
+  describe "reconcile_map/2" do
+    test "deindexes systems that are no longer in the fresh upstream list" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      stub(mock_registry, :systems_for_map, fn _slug -> ["31000001", "31000002", "31000003"] end)
+
+      stub(mock_registry, :deindex_system, fn slug, system_id ->
+        send(test_pid, {:deindex, slug, system_id})
+        :ok
+      end)
+
+      fetch_fun = fn _map_config ->
+        {:ok,
+         [
+           %{"solar_system_id" => 31_000_001, "name" => "A"},
+           %{"solar_system_id" => 31_000_002, "name" => "B"}
+         ]}
+      end
+
+      assert {:ok, :reconciled} =
+               Reconciler.reconcile_map(build_map_config(),
+                 registry: mock_registry,
+                 fetch_fun: fetch_fun
+               )
+
+      # 31000003 is stale — it must be deindexed
+      assert_received {:deindex, @map_slug, "31000003"}
+      # The other two remain — must not be deindexed
+      refute_received {:deindex, @map_slug, "31000001"}
+      refute_received {:deindex, @map_slug, "31000002"}
+    end
+
+    test "leaves state unchanged when upstream returns an empty list" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      stub(mock_registry, :systems_for_map, fn _slug -> ["31000001"] end)
+
+      stub(mock_registry, :deindex_system, fn slug, system_id ->
+        send(test_pid, {:deindex, slug, system_id})
+        :ok
+      end)
+
+      fetch_fun = fn _map_config -> {:ok, []} end
+
+      log =
+        capture_log(fn ->
+          assert {:ok, :skipped_empty} =
+                   Reconciler.reconcile_map(build_map_config(),
+                     registry: mock_registry,
+                     fetch_fun: fetch_fun
+                   )
+        end)
+
+      refute_received {:deindex, _, _}
+      assert log =~ "empty system list"
+    end
+
+    test "leaves state unchanged when upstream returns an error" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      stub(mock_registry, :systems_for_map, fn _slug -> ["31000001", "31000002"] end)
+
+      stub(mock_registry, :deindex_system, fn slug, system_id ->
+        send(test_pid, {:deindex, slug, system_id})
+        :ok
+      end)
+
+      fetch_fun = fn _map_config -> {:error, {:http_error, 503}} end
+
+      log =
+        capture_log(fn ->
+          assert {:error, {:http_error, 503}} =
+                   Reconciler.reconcile_map(build_map_config(),
+                     registry: mock_registry,
+                     fetch_fun: fetch_fun
+                   )
+        end)
+
+      refute_received {:deindex, _, _}
+      assert log =~ "fetch failed"
+    end
+
+    test "is a no-op when no systems are stale" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      stub(mock_registry, :systems_for_map, fn _slug -> ["31000001"] end)
+
+      stub(mock_registry, :deindex_system, fn slug, system_id ->
+        send(test_pid, {:deindex, slug, system_id})
+        :ok
+      end)
+
+      fetch_fun = fn _map_config -> {:ok, [%{"solar_system_id" => 31_000_001}]} end
+
+      assert {:ok, :reconciled} =
+               Reconciler.reconcile_map(build_map_config(),
+                 registry: mock_registry,
+                 fetch_fun: fetch_fun
+               )
+
+      refute_received {:deindex, _, _}
+    end
+
+    test "accepts fresh systems with string solar_system_id" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      stub(mock_registry, :systems_for_map, fn _slug -> ["31000001", "31000002"] end)
+
+      stub(mock_registry, :deindex_system, fn slug, system_id ->
+        send(test_pid, {:deindex, slug, system_id})
+        :ok
+      end)
+
+      # Production payload sometimes ships ids as strings
+      fetch_fun = fn _map_config ->
+        {:ok, [%{"solar_system_id" => "31000001"}]}
+      end
+
+      assert {:ok, :reconciled} =
+               Reconciler.reconcile_map(build_map_config(),
+                 registry: mock_registry,
+                 fetch_fun: fetch_fun
+               )
+
+      # 31000001 is still present (even as string) — must not be deindexed
+      refute_received {:deindex, @map_slug, "31000001"}
+      # 31000002 is stale
+      assert_received {:deindex, @map_slug, "31000002"}
+    end
+
+    test "ignores fresh systems without a parseable solar_system_id" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      stub(mock_registry, :systems_for_map, fn _slug -> ["31000001"] end)
+
+      stub(mock_registry, :deindex_system, fn slug, system_id ->
+        send(test_pid, {:deindex, slug, system_id})
+        :ok
+      end)
+
+      # Malformed entry with no resolvable id — should not cause 31000001 to be
+      # incorrectly considered stale
+      fetch_fun = fn _map_config ->
+        {:ok,
+         [
+           %{"solar_system_id" => 31_000_001},
+           %{"name" => "No id at all"}
+         ]}
+      end
+
+      assert {:ok, :reconciled} =
+               Reconciler.reconcile_map(build_map_config(),
+                 registry: mock_registry,
+                 fetch_fun: fetch_fun
+               )
+
+      refute_received {:deindex, _, _}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Users were receiving system kill notifications for systems that had been removed from their map, sometimes more than a day after removal. The MapRegistry reverse index (`system_id -> [map_slugs]`) is the single source of truth for killmail fan-out but was delta-maintained via SSE events only — any lost `deleted_system` event (silent SSE death, reconnect gaps, etc.) left a permanent stale row until the app restarted.
- Added an hourly `Map.Reconciler` GenServer that re-fetches the authoritative system list per map and prunes reverse-index rows no longer present upstream. Empty or error responses log a warning and leave state unchanged, so a transient API blip cannot wipe real tracking.
- Tightened `SystemHandler.handle_system_removal` to normalize the `solar_system_id` using the same logic as the add path, preventing a UUID payload value from ever being used as an ETS key and logging a warning on unresolvable ids.

## What changed

- **`lib/wanderer_notifier/map/reconciler.ex`** *(new)* — GenServer, 1h interval, first tick `+1h` after start, `Task.async_stream` at `max_concurrency: 5`. Public `reconcile_all/0` and `reconcile_map/2` for IEx invocation and testing. Catch-all `handle_info/2` mirroring the cfe85c5c pattern.
- **`lib/wanderer_notifier/domains/tracking/handlers/system_handler.ex`** — `handle_system_removal/3` now resolves ids through `Entities.System.normalize_solar_system_id/1`; unresolvable payloads log a warning and skip both the cache delete and the deindex instead of running with bogus keys. Extracted helpers for credo clarity.
- **`lib/wanderer_notifier/domains/tracking/entities/system.ex`** — promoted private `normalize_system_id/1` to public `normalize_solar_system_id/1` with explicit `@spec` and docstring.
- **`lib/wanderer_notifier/map/map_registry.ex`** — new `systems_for_map/1` via `:ets.match_object` for the reconcile diff.
- **`lib/wanderer_notifier/map/map_registry_behaviour.ex`** — added `index_system/2`, `deindex_system/2`, `index_character/2`, `deindex_character/2`, `systems_for_map/1` callbacks so Mox can stub them.
- **`lib/wanderer_notifier/application/initialization/service_initializer.ex`** — wired `Map.Reconciler` into `processing_phase` after `SSESupervisor`.
- **`mix.exs`** — version bump to 6.1.1.

## Tests added (all test-first, red→green)

- `test/wanderer_notifier/domains/tracking/entities/system_test.exs` — 6 tests for `normalize_solar_system_id/1` (int passthrough, int-valued binary, UUID, empty, nil, trailing garbage).
- `test/wanderer_notifier/domains/tracking/handlers/system_handler_test.exs` — 2 new removal tests: normalized integer key is used when both fields present; warning + no ETS operations when only an unparseable id is present.
- `test/wanderer_notifier/map/map_registry_test.exs` — 4 tests for `systems_for_map/1` (empty, per-slug filtering, slug isolation, shared-system bag semantics).
- `test/wanderer_notifier/map/reconciler_test.exs` *(new)* — 6 tests: stale prune, empty response no-op, error response no-op, no-stale no-op, string solar_system_id accepted, malformed fresh entries ignored.

## Out of scope (per discussion)

- Character index is not reconciled — character rosters rarely change and doing both would double API traffic without a corresponding payoff.
- No env var for the interval — hardcoded to 1 hour.
- No enabled flag — runs unconditionally.

## Operational notes

- First reconcile runs one full hour after app start, so `Map.Initializer`'s startup fetch always gets the first word.
- Worst-case ghost-notification window is now bounded by ~1 hour instead of "until restart."
- Manual reconcile from IEx: `WandererNotifier.Map.Reconciler.reconcile_all/0`.
- Log filter to watch: `category: :reconcile`. The `Reconciler: pruning stale systems from reverse index` line carries a `stale_count` — double-digit counts per map per hour signal that SSE delete events are being lost and the underlying SSE stability story still has work to do.

## Test plan

- [x] `make compile.strict` — no warnings
- [x] `make test` — 524 tests, 0 failures, 1 skipped
- [x] `mix credo --strict` — no issues
- [x] `mix dialyzer` — passes (3 pre-existing skipped errors unchanged)
- [x] `./scripts/validate-quality.sh` — all 4 gates pass
- [ ] Deploy to staging, watch `category: :reconcile` logs for an hour, confirm first tick runs and pruning counts are sane
- [ ] Confirm with affected user that ghost notifications stop within 1 hour of rollout



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hourly map reconciliation service to detect and remove stale systems missed by real-time deletes.

* **Bug Fixes**
  * Stricter solar-system ID parsing and normalization to avoid mis-identified removals.
  * Consolidated removal flow with improved safe deindexing and clearer warnings on unresolvable IDs.

* **Tests**
  * Expanded test coverage for reconciliation, ID normalization, and removal/deindexing behaviors.

* **Chores**
  * Version bumped to 6.1.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->