### PR TITLE
fix: improve Discord notification delivery reliability

### DIFF
--- a/lib/wanderer_notifier/discord_notifier.ex
+++ b/lib/wanderer_notifier/discord_notifier.ex
@@ -14,6 +14,7 @@ defmodule WandererNotifier.DiscordNotifier do
 
   require Logger
   alias WandererNotifier.Shared.Config
+  alias WandererNotifier.Domains.Notifications.Discord.ConnectionHealth
   alias WandererNotifier.Domains.Notifications.Formatters.NotificationFormatter
   alias WandererNotifier.Domains.Notifications.Notifiers.Discord.NeoClient
   alias WandererNotifier.Infrastructure.Adapters.Discord.VoiceParticipants
@@ -298,8 +299,6 @@ defmodule WandererNotifier.DiscordNotifier do
   defp record_failed_kill(nil, _reason), do: {:ok, :recorded}
 
   defp record_failed_kill(killmail_id, reason) do
-    alias WandererNotifier.Domains.Notifications.Discord.ConnectionHealth
-
     # Use record_failed_killmail to add to the failed kills list without affecting counters
     # (NeoClient already records the failure/timeout for health metrics)
     case ConnectionHealth.record_failed_killmail(killmail_id, reason) do
@@ -583,6 +582,8 @@ defmodule WandererNotifier.DiscordNotifier do
 
     case result do
       {:ok, :sent} ->
+        ConnectionHealth.record_success()
+
         Logger.info("Discord notification sent for map #{mc.slug}",
           channel: channel_id,
           map_slug: mc.slug
@@ -591,6 +592,8 @@ defmodule WandererNotifier.DiscordNotifier do
         {:ok, :sent}
 
       {:error, reason} ->
+        ConnectionHealth.record_failure(reason)
+
         Logger.error("Discord notification failed for map #{mc.slug}",
           channel: channel_id,
           map_slug: mc.slug,

--- a/lib/wanderer_notifier/discord_notifier.ex
+++ b/lib/wanderer_notifier/discord_notifier.ex
@@ -299,8 +299,9 @@ defmodule WandererNotifier.DiscordNotifier do
   defp record_failed_kill(nil, _reason), do: {:ok, :recorded}
 
   defp record_failed_kill(killmail_id, reason) do
-    # Use record_failed_killmail to add to the failed kills list without affecting counters
-    # (NeoClient already records the failure/timeout for health metrics)
+    # Use record_failed_killmail to add to the failed kills list without affecting counters.
+    # Health counters (total_successes, total_failures) are tracked per-channel-send
+    # in send_to_discord_for_map via ConnectionHealth.record_success/record_failure.
     case ConnectionHealth.record_failed_killmail(killmail_id, reason) do
       {:ok, _} ->
         {:ok, :recorded}

--- a/lib/wanderer_notifier/domains/notifications/discord/connection_health.ex
+++ b/lib/wanderer_notifier/domains/notifications/discord/connection_health.ex
@@ -238,7 +238,9 @@ defmodule WandererNotifier.Domains.Notifications.Discord.ConnectionHealth do
 
   @impl true
   def handle_cast({:record_failed_killmail, killmail_id, reason}, state) do
-    # Only add to failed_kills list, don't affect counters (NeoClient handles those)
+    # Only add to failed_kills list, don't affect counters.
+    # Health counters are recorded separately via record_success/record_failure
+    # at the send site (discord_notifier.ex send_to_discord_for_map).
     new_state = %{
       state
       | failed_kills: add_failed_kill(state.failed_kills, killmail_id, reason)

--- a/lib/wanderer_notifier/domains/notifications/discord/http_client.ex
+++ b/lib/wanderer_notifier/domains/notifications/discord/http_client.ex
@@ -24,6 +24,9 @@ defmodule WandererNotifier.Domains.Notifications.Discord.HttpClient do
 
   @discord_embed_key_map Map.new(@discord_embed_keys, fn key -> {key, String.to_atom(key)} end)
 
+  @max_retries 2
+  @initial_retry_delay_ms 500
+
   @type embed :: map()
   @type channel_id :: String.t() | integer()
   @type bot_token :: String.t()
@@ -78,37 +81,66 @@ defmodule WandererNotifier.Domains.Notifications.Discord.HttpClient do
     defaults = [service: :discord, rate_limit: [bucket_key: token_bucket_key(bot_token)]]
     opts = Keyword.merge(defaults, caller_opts)
 
-    case Http.request(:post, url, payload, headers, opts) do
-      {:ok, %{status_code: status}} when status in 200..299 ->
-        {:ok, :sent}
+    do_send_with_retry(url, payload, headers, opts, channel_id, _attempt = 0)
+  end
 
-      {:ok, %{status_code: 429, body: body}} ->
-        retry_after = extract_retry_after(body)
+  defp do_send_with_retry(url, payload, headers, opts, channel_id, attempt) do
+    result = Http.request(:post, url, payload, headers, opts)
 
-        Logger.warning("Discord rate limited",
-          channel_id: channel_id,
-          retry_after: retry_after
-        )
+    case handle_response(result, channel_id) do
+      {:retry, reason} when attempt < @max_retries ->
+        delay = retry_delay(attempt)
+        log_retry(channel_id, reason, attempt)
+        Process.sleep(delay)
+        do_send_with_retry(url, payload, headers, opts, channel_id, attempt + 1)
 
-        {:error, {:rate_limited, retry_after}}
-
-      {:ok, %{status_code: status, body: body}} ->
-        Logger.error("Discord API error",
-          status: status,
-          channel_id: channel_id,
-          body: inspect(body)
-        )
-
-        {:error, {:discord_api_error, status}}
-
-      {:error, reason} ->
-        Logger.error("Discord request failed",
-          channel_id: channel_id,
-          error: inspect(reason)
-        )
-
+      {:retry, reason} ->
+        log_exhausted(channel_id, reason)
         {:error, reason}
+
+      final ->
+        final
     end
+  end
+
+  defp handle_response({:ok, %{status_code: status}}, _channel_id) when status in 200..299 do
+    {:ok, :sent}
+  end
+
+  defp handle_response({:ok, %{status_code: 429, body: body}}, channel_id) do
+    retry_after = extract_retry_after(body)
+    Logger.warning("Discord rate limited", channel_id: channel_id, retry_after: retry_after)
+    {:error, {:rate_limited, retry_after}}
+  end
+
+  defp handle_response({:ok, %{status_code: status, body: body}}, channel_id) do
+    Logger.error("Discord API error", status: status, channel_id: channel_id, body: inspect(body))
+    {:error, {:discord_api_error, status}}
+  end
+
+  defp handle_response({:error, reason}, _channel_id) do
+    {:retry, reason}
+  end
+
+  defp log_retry(channel_id, reason, attempt) do
+    Logger.warning("Discord transport error, retrying",
+      channel_id: channel_id,
+      error: inspect(reason),
+      attempt: attempt + 1,
+      max_retries: @max_retries,
+      retry_in_ms: retry_delay(attempt)
+    )
+  end
+
+  defp log_exhausted(channel_id, reason) do
+    Logger.error("Discord request failed after #{@max_retries} retries",
+      channel_id: channel_id,
+      error: inspect(reason)
+    )
+  end
+
+  defp retry_delay(attempt) do
+    trunc(@initial_retry_delay_ms * :math.pow(2, attempt))
   end
 
   defp extract_retry_after(%{"retry_after" => seconds}) when is_number(seconds), do: seconds

--- a/test/wanderer_notifier/domains/notifications/discord/connection_health_test.exs
+++ b/test/wanderer_notifier/domains/notifications/discord/connection_health_test.exs
@@ -1,0 +1,61 @@
+defmodule WandererNotifier.Domains.Notifications.Discord.ConnectionHealthTest do
+  use ExUnit.Case, async: false
+
+  alias WandererNotifier.Domains.Notifications.Discord.ConnectionHealth
+
+  setup do
+    # Stop existing instance if running, start fresh for each test
+    case GenServer.whereis(ConnectionHealth) do
+      nil -> :ok
+      pid -> GenServer.stop(pid, :normal)
+    end
+
+    {:ok, _pid} = ConnectionHealth.start_link([])
+
+    on_exit(fn ->
+      case GenServer.whereis(ConnectionHealth) do
+        nil -> :ok
+        pid -> GenServer.stop(pid, :normal)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "record_success/0" do
+    test "increments total_successes counter" do
+      ConnectionHealth.record_success()
+      ConnectionHealth.record_success()
+      # Give GenServer time to process casts
+      Process.sleep(50)
+
+      {:ok, status} = ConnectionHealth.get_health_status()
+      assert status.total_successes == 2
+    end
+  end
+
+  describe "record_failure/2" do
+    test "increments total_failures counter and adds to failed_kills" do
+      ConnectionHealth.record_failure(:timeout, "kill-123")
+      Process.sleep(50)
+
+      {:ok, status} = ConnectionHealth.get_health_status()
+      assert status.total_failures == 1
+      assert length(status.failed_kills) == 1
+      assert hd(status.failed_kills).killmail_id == "kill-123"
+    end
+  end
+
+  describe "record_failed_killmail/2" do
+    test "adds to failed_kills list without incrementing counters" do
+      ConnectionHealth.record_failed_killmail("kill-456", :partial_failure)
+      Process.sleep(50)
+
+      {:ok, status} = ConnectionHealth.get_health_status()
+      assert status.total_failures == 0
+      assert status.total_successes == 0
+      assert length(status.failed_kills) == 1
+      assert hd(status.failed_kills).killmail_id == "kill-456"
+    end
+  end
+end

--- a/test/wanderer_notifier/domains/notifications/discord/http_client_test.exs
+++ b/test/wanderer_notifier/domains/notifications/discord/http_client_test.exs
@@ -1,0 +1,63 @@
+defmodule WandererNotifier.Domains.Notifications.Discord.HttpClientTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias WandererNotifier.Domains.Notifications.Discord.HttpClient
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  describe "send_embed/3 retry on transport errors" do
+    test "succeeds on first attempt without retry" do
+      WandererNotifier.HTTPMock
+      |> expect(:request, 1, fn :post, _url, _body, _headers, _opts ->
+        {:ok, %{status_code: 200, body: %{}}}
+      end)
+
+      assert {:ok, :sent} = HttpClient.send_embed("bot-token", "123456", %{title: "Test"})
+    end
+
+    test "retries on transport error and succeeds" do
+      WandererNotifier.HTTPMock
+      |> expect(:request, 1, fn :post, _url, _body, _headers, _opts ->
+        {:error, %Req.TransportError{reason: :timeout}}
+      end)
+      |> expect(:request, 1, fn :post, _url, _body, _headers, _opts ->
+        {:ok, %{status_code: 200, body: %{}}}
+      end)
+
+      assert {:ok, :sent} = HttpClient.send_embed("bot-token", "123456", %{title: "Test"})
+    end
+
+    test "returns error after exhausting retries on transport errors" do
+      WandererNotifier.HTTPMock
+      |> expect(:request, 3, fn :post, _url, _body, _headers, _opts ->
+        {:error, %Req.TransportError{reason: :timeout}}
+      end)
+
+      assert {:error, %Req.TransportError{reason: :timeout}} =
+               HttpClient.send_embed("bot-token", "123456", %{title: "Test"})
+    end
+
+    test "does not retry on HTTP-level errors" do
+      WandererNotifier.HTTPMock
+      |> expect(:request, 1, fn :post, _url, _body, _headers, _opts ->
+        {:ok, %{status_code: 500, body: %{"message" => "Internal Server Error"}}}
+      end)
+
+      assert {:error, {:discord_api_error, 500}} =
+               HttpClient.send_embed("bot-token", "123456", %{title: "Test"})
+    end
+
+    test "does not retry on rate limit responses" do
+      WandererNotifier.HTTPMock
+      |> expect(:request, 1, fn :post, _url, _body, _headers, _opts ->
+        {:ok, %{status_code: 429, body: %{"retry_after" => 1.5}}}
+      end)
+
+      assert {:error, {:rate_limited, 1.5}} =
+               HttpClient.send_embed("bot-token", "123456", %{title: "Test"})
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Add retry with exponential backoff to Discord HttpClient** for transport-level errors (TCP timeout, connection refused). 2 retries with 500ms/1000ms backoff. HTTP errors and rate limits are NOT retried to avoid duplicate messages.
- **Wire ConnectionHealth tracking into the HttpClient send path** so health metrics (`total_success`, `total_failures`) actually reflect send outcomes. Previously the health dashboard was blind — showing `total_success=0` even after successful sends.
- **Fix misleading comments** that referenced NeoClient as the health counter owner, and add ConnectionHealth GenServer tests.

## Root Cause

The notification pipeline always fans out via MapRegistry, producing a MapConfig even in single-map mode. This routes all sends through `DiscordHttpClient` (direct REST), bypassing the Nostrum path which had retries and health tracking. Any transient transport error silently lost the kill notification permanently.

## Test plan

- [x] 5 new HttpClient retry tests (success, retry-then-success, exhausted retries, no retry on 500, no retry on 429)
- [x] 3 new ConnectionHealth counter tests (record_success, record_failure, record_failed_killmail)
- [x] `make compile` — clean
- [x] `make test` — all tests pass
- [x] `mix credo --strict` — no issues
- [x] `mix dialyzer` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic retry mechanism: Discord message delivery now automatically retries failed sends up to 2 times with exponential backoff delays, improving overall delivery reliability.
  * Rate-limit handling: Discord API rate-limit responses are now explicitly detected and reported with accurate retry-after timing information.
  * Enhanced health tracking: Per-map-channel health metrics now independently track message delivery success and failure statistics for better system visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->