### PR TITLE
fix: add retry logic for WebSocket and SSE startup failures

### DIFF
--- a/lib/wanderer_notifier/domains/killmail/supervisor.ex
+++ b/lib/wanderer_notifier/domains/killmail/supervisor.ex
@@ -136,9 +136,21 @@ defmodule WandererNotifier.Domains.Killmail.Supervisor do
   defp start_websocket_client do
     Logger.info("Starting WebSocket client", category: :processor)
 
-    case WandererNotifier.Domains.Killmail.WebSocketClient.start_link() do
+    child_spec = %{
+      id: WandererNotifier.Domains.Killmail.WebSocketClient,
+      start: {WandererNotifier.Domains.Killmail.WebSocketClient, :start_link, [[]]},
+      restart: :permanent,
+      shutdown: 5000,
+      type: :worker
+    }
+
+    case Supervisor.start_child(__MODULE__.InternalSupervisor, child_spec) do
       {:ok, pid} ->
         Logger.info("WebSocket client started successfully", pid: inspect(pid))
+        {:ok, pid}
+
+      {:error, {:already_started, pid}} ->
+        Logger.info("WebSocket client already running", pid: inspect(pid))
         {:ok, pid}
 
       {:error, reason} ->

--- a/lib/wanderer_notifier/domains/killmail/supervisor.ex
+++ b/lib/wanderer_notifier/domains/killmail/supervisor.ex
@@ -13,6 +13,9 @@ defmodule WandererNotifier.Domains.Killmail.Supervisor do
   use GenServer
   require Logger
 
+  @initial_retry_delay 5_000
+  @max_retry_delay 60_000
+
   @doc """
   Starts the Killmail Supervisor.
   """
@@ -76,21 +79,44 @@ defmodule WandererNotifier.Domains.Killmail.Supervisor do
 
   @impl true
   def handle_continue(:start_websocket, state) do
-    # Start WebSocket client using TaskSupervisor for proper crash propagation
-    case Task.Supervisor.start_child(WandererNotifier.TaskSupervisor, fn ->
-           start_websocket_client()
-         end) do
+    case start_websocket_client() do
       {:ok, _pid} ->
         {:noreply, state}
 
       {:error, reason} ->
-        Logger.error("Failed to start WebSocket client task",
+        Logger.warning("WebSocket client failed to start, scheduling retry",
           reason: inspect(reason),
+          retry_in_ms: @initial_retry_delay,
           category: :processor
         )
 
-        # Continue running - the fallback handler will provide HTTP-based access
-        {:noreply, state}
+        schedule_websocket_retry(state, 0)
+    end
+  end
+
+  @impl true
+  def handle_info(:retry_websocket, state) do
+    attempts = Map.get(state, :ws_retry_attempts, 0)
+
+    case start_websocket_client() do
+      {:ok, _pid} ->
+        Logger.info("WebSocket client started after #{attempts + 1} retry attempt(s)",
+          category: :processor
+        )
+
+        {:noreply, Map.delete(state, :ws_retry_attempts)}
+
+      {:error, reason} ->
+        delay = calculate_retry_delay(attempts + 1)
+
+        Logger.warning("WebSocket client retry failed, will retry again",
+          reason: inspect(reason),
+          attempt: attempts + 1,
+          retry_in_ms: delay,
+          category: :processor
+        )
+
+        schedule_websocket_retry(state, attempts + 1)
     end
   end
 
@@ -108,7 +134,7 @@ defmodule WandererNotifier.Domains.Killmail.Supervisor do
   # ──────────────────────────────────────────────────────────────────────────────
 
   defp start_websocket_client do
-    Logger.info("Starting WebSocket client via TaskSupervisor", category: :processor)
+    Logger.info("Starting WebSocket client", category: :processor)
 
     case WandererNotifier.Domains.Killmail.WebSocketClient.start_link() do
       {:ok, pid} ->
@@ -116,11 +142,23 @@ defmodule WandererNotifier.Domains.Killmail.Supervisor do
         {:ok, pid}
 
       {:error, reason} ->
-        Logger.warning("WebSocket client failed to start, will be handled by fallback",
-          reason: inspect(reason)
+        Logger.warning("WebSocket client failed to start",
+          reason: inspect(reason),
+          category: :processor
         )
 
         {:error, reason}
     end
+  end
+
+  defp schedule_websocket_retry(state, attempts) do
+    delay = calculate_retry_delay(attempts)
+    Process.send_after(self(), :retry_websocket, delay)
+    {:noreply, Map.put(state, :ws_retry_attempts, attempts)}
+  end
+
+  defp calculate_retry_delay(attempts) do
+    delay = @initial_retry_delay * Integer.pow(2, min(attempts, 10))
+    min(delay, @max_retry_delay)
   end
 end

--- a/lib/wanderer_notifier/domains/killmail/supervisor.ex
+++ b/lib/wanderer_notifier/domains/killmail/supervisor.ex
@@ -90,7 +90,7 @@ defmodule WandererNotifier.Domains.Killmail.Supervisor do
           category: :processor
         )
 
-        schedule_websocket_retry(state, 0)
+        {:noreply, schedule_websocket_retry(state, 0)}
     end
   end
 
@@ -107,16 +107,16 @@ defmodule WandererNotifier.Domains.Killmail.Supervisor do
         {:noreply, Map.delete(state, :ws_retry_attempts)}
 
       {:error, reason} ->
-        delay = calculate_retry_delay(attempts + 1)
+        new_attempts = attempts + 1
 
         Logger.warning("WebSocket client retry failed, will retry again",
           reason: inspect(reason),
-          attempt: attempts + 1,
-          retry_in_ms: delay,
+          attempt: new_attempts,
+          retry_in_ms: calculate_retry_delay(new_attempts),
           category: :processor
         )
 
-        schedule_websocket_retry(state, attempts + 1)
+        {:noreply, schedule_websocket_retry(state, new_attempts)}
     end
   end
 
@@ -152,9 +152,8 @@ defmodule WandererNotifier.Domains.Killmail.Supervisor do
   end
 
   defp schedule_websocket_retry(state, attempts) do
-    delay = calculate_retry_delay(attempts)
-    Process.send_after(self(), :retry_websocket, delay)
-    {:noreply, Map.put(state, :ws_retry_attempts, attempts)}
+    Process.send_after(self(), :retry_websocket, calculate_retry_delay(attempts))
+    Map.put(state, :ws_retry_attempts, attempts)
   end
 
   defp calculate_retry_delay(attempts) do

--- a/lib/wanderer_notifier/map/sse_supervisor.ex
+++ b/lib/wanderer_notifier/map/sse_supervisor.ex
@@ -401,20 +401,18 @@ defmodule WandererNotifier.Map.SSESupervisor do
       category: :startup
     )
 
-    {still_failed, newly_succeeded} =
-      Enum.split_with(maps, fn map ->
-        case initialize_and_start_for_map(map) do
-          {:ok, _pid} -> false
-          {:error, _} -> true
-        end
-      end)
+    results = Enum.map(maps, fn map -> {map, initialize_and_start_for_map(map)} end)
 
-    if newly_succeeded != [] do
-      slugs = Enum.map(newly_succeeded, & &1.slug)
+    {succeeded, still_failed} =
+      Enum.split_with(results, fn {_map, result} -> match?({:ok, _}, result) end)
+
+    if succeeded != [] do
+      slugs = Enum.map(succeeded, fn {map, _} -> map.slug end)
       Logger.info("Map initialization retry succeeded", map_slugs: slugs, category: :startup)
     end
 
-    schedule_failed_map_retries(still_failed, attempt + 1)
+    failed_maps = Enum.map(still_failed, fn {map, _} -> map end)
+    schedule_failed_map_retries(failed_maps, attempt + 1)
   end
 
   defp calculate_init_retry_delay(attempt) do

--- a/lib/wanderer_notifier/map/sse_supervisor.ex
+++ b/lib/wanderer_notifier/map/sse_supervisor.ex
@@ -211,6 +211,8 @@ defmodule WandererNotifier.Map.SSESupervisor do
 
     # Schedule retry for failed maps
     schedule_failed_map_retries(failed_maps, 1)
+
+    :ok
   end
 
   defp run_parallel_init(maps) do
@@ -377,6 +379,8 @@ defmodule WandererNotifier.Map.SSESupervisor do
       map_slugs: slugs,
       category: :startup
     )
+
+    :ok
   end
 
   defp schedule_failed_map_retries(failed_maps, attempt) do
@@ -389,18 +393,54 @@ defmodule WandererNotifier.Map.SSESupervisor do
       category: :startup
     )
 
-    Task.Supervisor.start_child(WandererNotifier.TaskSupervisor, fn ->
-      Process.sleep(delay)
-      retry_failed_maps(failed_maps, attempt)
-    end)
+    case Task.Supervisor.start_child(WandererNotifier.TaskSupervisor, fn ->
+           Process.sleep(delay)
+           retry_failed_maps(failed_maps, attempt)
+         end) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("Failed to schedule map initialization retry",
+          attempt: attempt,
+          reason: inspect(reason),
+          category: :startup
+        )
+
+        :ok
+    end
   end
 
   defp retry_failed_maps(maps, attempt) do
-    Logger.info("Retrying initialization for #{length(maps)} map(s)",
-      attempt: attempt,
-      category: :startup
-    )
+    maps = filter_live_maps(maps)
 
+    if maps == [] do
+      Logger.info("All previously failed maps have been removed from registry, skipping retry",
+        attempt: attempt,
+        category: :startup
+      )
+
+      :ok
+    else
+      Logger.info("Retrying initialization for #{length(maps)} map(s)",
+        attempt: attempt,
+        category: :startup
+      )
+
+      failed_maps = attempt_map_initialization(maps)
+      schedule_failed_map_retries(failed_maps, attempt + 1)
+    end
+  end
+
+  defp filter_live_maps(maps) do
+    live_slugs =
+      Dependencies.map_registry().all_maps()
+      |> MapSet.new(& &1.slug)
+
+    Enum.filter(maps, &MapSet.member?(live_slugs, &1.slug))
+  end
+
+  defp attempt_map_initialization(maps) do
     results = Enum.map(maps, fn map -> {map, initialize_and_start_for_map(map)} end)
 
     {succeeded, still_failed} =
@@ -411,8 +451,7 @@ defmodule WandererNotifier.Map.SSESupervisor do
       Logger.info("Map initialization retry succeeded", map_slugs: slugs, category: :startup)
     end
 
-    failed_maps = Enum.map(still_failed, fn {map, _} -> map end)
-    schedule_failed_map_retries(failed_maps, attempt + 1)
+    Enum.map(still_failed, fn {map, _} -> map end)
   end
 
   defp calculate_init_retry_delay(attempt) do

--- a/lib/wanderer_notifier/map/sse_supervisor.ex
+++ b/lib/wanderer_notifier/map/sse_supervisor.ex
@@ -207,10 +207,10 @@ defmodule WandererNotifier.Map.SSESupervisor do
     signal_pipeline_worker()
 
     # Start SSE clients only for successfully initialized maps
-    start_sse_clients_staggered(successful_maps)
+    failed_sse_maps = start_sse_clients_staggered(successful_maps)
 
-    # Schedule retry for failed maps
-    schedule_failed_map_retries(failed_maps, 1)
+    # Schedule retry for all failures (data init + SSE startup)
+    schedule_failed_map_retries(failed_maps ++ failed_sse_maps, 1)
 
     :ok
   end
@@ -303,7 +303,9 @@ defmodule WandererNotifier.Map.SSESupervisor do
   defp start_sse_clients_staggered(maps) do
     results =
       maps
-      |> Task.async_stream(&start_sse_client_for_map/1,
+      |> Enum.map(fn map -> {map, nil} end)
+      |> Task.async_stream(
+        fn {map, _} -> {map, start_sse_client_for_map(map)} end,
         max_concurrency: 5,
         timeout: 30_000
       )
@@ -311,16 +313,21 @@ defmodule WandererNotifier.Map.SSESupervisor do
 
     {succeeded, failed} =
       Enum.split_with(results, fn
-        {:ok, {:ok, _pid}} -> true
+        {:ok, {_map, {:ok, _pid}}} -> true
         _ -> false
       end)
 
+    log_sse_startup_results(succeeded, failed, length(maps))
+    extract_failed_sse_maps(failed)
+  end
+
+  defp log_sse_startup_results(succeeded, failed, total) do
     succeeded_count = length(succeeded)
     failed_count = length(failed)
 
     if failed_count > 0 do
       Enum.each(failed, fn
-        {:ok, {:error, reason}} ->
+        {:ok, {_map, {:error, reason}}} ->
           Logger.warning("SSE client startup failed", reason: inspect(reason))
 
         {:exit, reason} ->
@@ -331,12 +338,19 @@ defmodule WandererNotifier.Map.SSESupervisor do
       end)
 
       Logger.warning(
-        "SSE client startup: #{succeeded_count} succeeded, #{failed_count} failed out of #{length(maps)}",
+        "SSE client startup: #{succeeded_count} succeeded, #{failed_count} failed out of #{total}",
         category: :startup
       )
     else
       Logger.info("Started #{succeeded_count} SSE clients", category: :startup)
     end
+  end
+
+  defp extract_failed_sse_maps(failed_results) do
+    Enum.flat_map(failed_results, fn
+      {:ok, {%MapConfig{} = mc, {:error, _}}} -> [mc]
+      _ -> []
+    end)
   end
 
   defp start_sse_client_for_map(%MapConfig{} = map_config) do
@@ -395,7 +409,8 @@ defmodule WandererNotifier.Map.SSESupervisor do
 
     case Task.Supervisor.start_child(WandererNotifier.TaskSupervisor, fn ->
            Process.sleep(delay)
-           retry_failed_maps(failed_maps, attempt)
+           fresh_maps = fetch_fresh_configs(failed_maps)
+           retry_failed_maps(fresh_maps, attempt)
          end) do
       {:ok, _pid} ->
         :ok
@@ -411,25 +426,23 @@ defmodule WandererNotifier.Map.SSESupervisor do
     end
   end
 
+  defp retry_failed_maps([], attempt) do
+    Logger.info("All previously failed maps have been removed from registry, skipping retry",
+      attempt: attempt,
+      category: :startup
+    )
+
+    :ok
+  end
+
   defp retry_failed_maps(maps, attempt) do
-    maps = fetch_fresh_configs(maps)
+    Logger.info("Retrying initialization for #{length(maps)} map(s)",
+      attempt: attempt,
+      category: :startup
+    )
 
-    if maps == [] do
-      Logger.info("All previously failed maps have been removed from registry, skipping retry",
-        attempt: attempt,
-        category: :startup
-      )
-
-      :ok
-    else
-      Logger.info("Retrying initialization for #{length(maps)} map(s)",
-        attempt: attempt,
-        category: :startup
-      )
-
-      failed_maps = attempt_map_initialization(maps)
-      schedule_failed_map_retries(failed_maps, attempt + 1)
-    end
+    failed_maps = attempt_map_initialization(maps)
+    schedule_failed_map_retries(failed_maps, attempt + 1)
   end
 
   defp fetch_fresh_configs(maps) do

--- a/lib/wanderer_notifier/map/sse_supervisor.ex
+++ b/lib/wanderer_notifier/map/sse_supervisor.ex
@@ -412,7 +412,7 @@ defmodule WandererNotifier.Map.SSESupervisor do
   end
 
   defp retry_failed_maps(maps, attempt) do
-    maps = filter_live_maps(maps)
+    maps = fetch_fresh_configs(maps)
 
     if maps == [] do
       Logger.info("All previously failed maps have been removed from registry, skipping retry",
@@ -432,12 +432,15 @@ defmodule WandererNotifier.Map.SSESupervisor do
     end
   end
 
-  defp filter_live_maps(maps) do
-    live_slugs =
-      Dependencies.map_registry().all_maps()
-      |> MapSet.new(& &1.slug)
+  defp fetch_fresh_configs(maps) do
+    registry = Dependencies.map_registry()
 
-    Enum.filter(maps, &MapSet.member?(live_slugs, &1.slug))
+    Enum.flat_map(maps, fn map ->
+      case registry.get_map(map.slug) do
+        {:ok, fresh_config} -> [fresh_config]
+        {:error, _} -> []
+      end
+    end)
   end
 
   defp attempt_map_initialization(maps) do

--- a/lib/wanderer_notifier/map/sse_supervisor.ex
+++ b/lib/wanderer_notifier/map/sse_supervisor.ex
@@ -13,6 +13,10 @@ defmodule WandererNotifier.Map.SSESupervisor do
   alias WandererNotifier.Map.{Initializer, MapConfig, SSEClient}
   alias WandererNotifier.Shared.Dependencies
 
+  @max_init_retries 5
+  @initial_retry_delay 10_000
+  @max_retry_delay 60_000
+
   @doc """
   Starts the SSE supervisor.
   """
@@ -197,13 +201,16 @@ defmodule WandererNotifier.Map.SSESupervisor do
     maps = Dependencies.map_registry().all_maps()
     Logger.info("Initializing #{length(maps)} maps from registry", category: :startup)
 
-    successful_maps = run_parallel_init(maps)
+    {successful_maps, failed_maps} = run_parallel_init(maps)
 
     # Signal PipelineWorker
     signal_pipeline_worker()
 
     # Start SSE clients only for successfully initialized maps
     start_sse_clients_staggered(successful_maps)
+
+    # Schedule retry for failed maps
+    schedule_failed_map_retries(failed_maps, 1)
   end
 
   defp run_parallel_init(maps) do
@@ -223,6 +230,7 @@ defmodule WandererNotifier.Map.SSESupervisor do
     log_initialization_failures(failed)
 
     successful_maps = Enum.map(succeeded, fn {{:ok, {map, _}}, _} -> map end)
+    failed_maps = extract_failed_maps(failed)
 
     if failed != [] do
       Logger.warning(
@@ -232,7 +240,14 @@ defmodule WandererNotifier.Map.SSESupervisor do
       )
     end
 
-    successful_maps
+    {successful_maps, failed_maps}
+  end
+
+  defp extract_failed_maps(failed_items) do
+    Enum.flat_map(failed_items, fn
+      {%MapConfig{} = mc, _reason} -> [mc]
+      _ -> []
+    end)
   end
 
   defp partition_init_results(results) do
@@ -346,6 +361,65 @@ defmodule WandererNotifier.Map.SSESupervisor do
   @spec initialize_map_data_safely(MapConfig.t()) :: {:ok, :initialized} | {:error, term()}
   defp initialize_map_data_safely(%MapConfig{} = map_config) do
     Initializer.initialize_map_data_for(map_config)
+  end
+
+  # ──────────────────────────────────────────────────────────────────────────────
+  # Retry Logic for Failed Map Initialization
+  # ──────────────────────────────────────────────────────────────────────────────
+
+  defp schedule_failed_map_retries([], _attempt), do: :ok
+
+  defp schedule_failed_map_retries(failed_maps, attempt) when attempt > @max_init_retries do
+    slugs = Enum.map(failed_maps, & &1.slug)
+
+    Logger.error(
+      "Giving up on map initialization after #{@max_init_retries} retries",
+      map_slugs: slugs,
+      category: :startup
+    )
+  end
+
+  defp schedule_failed_map_retries(failed_maps, attempt) do
+    delay = calculate_init_retry_delay(attempt)
+    slugs = Enum.map(failed_maps, & &1.slug)
+
+    Logger.info(
+      "Scheduling retry #{attempt}/#{@max_init_retries} for #{length(failed_maps)} failed map(s) in #{delay}ms",
+      map_slugs: slugs,
+      category: :startup
+    )
+
+    Task.Supervisor.start_child(WandererNotifier.TaskSupervisor, fn ->
+      Process.sleep(delay)
+      retry_failed_maps(failed_maps, attempt)
+    end)
+  end
+
+  defp retry_failed_maps(maps, attempt) do
+    Logger.info("Retrying initialization for #{length(maps)} map(s)",
+      attempt: attempt,
+      category: :startup
+    )
+
+    {still_failed, newly_succeeded} =
+      Enum.split_with(maps, fn map ->
+        case initialize_and_start_for_map(map) do
+          {:ok, _pid} -> false
+          {:error, _} -> true
+        end
+      end)
+
+    if newly_succeeded != [] do
+      slugs = Enum.map(newly_succeeded, & &1.slug)
+      Logger.info("Map initialization retry succeeded", map_slugs: slugs, category: :startup)
+    end
+
+    schedule_failed_map_retries(still_failed, attempt + 1)
+  end
+
+  defp calculate_init_retry_delay(attempt) do
+    delay = @initial_retry_delay * Integer.pow(2, min(attempt - 1, 10))
+    min(delay, @max_retry_delay)
   end
 
   # ──────────────────────────────────────────────────────────────────────────────

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule WandererNotifier.MixProject do
   def project do
     [
       app: :wanderer_notifier,
-      version: "6.1.3",
+      version: "6.1.4",
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
When upstream services are temporarily unreachable during app startup, both WebSocket and SSE clients would fail their initial connection with no recovery path — leaving the app in a permanently broken state until manually restarted.

WebSocket: Replace fire-and-forget Task with retry loop using exponential backoff (5s–60s) in the Killmail Supervisor GenServer.

SSE: Retry failed map initialization up to 5 times with exponential backoff (10s–60s) via TaskSupervisor, re-attempting initialize_and_start_for_map for each failed map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic connection recovery for WebSocket clients with scheduled retries, attempt tracking, and exponential backoff.
  * Per-map retry subsystem for map initialization that retries failed items individually with capped, increasing delays.

* **Improvements**
  * Clearer logging for retry scheduling, attempts, successes, skips, and eventual give-up to improve observability and resilience.

* **Chores**
  * Release version bumped to 6.1.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->