### PR TITLE
fix: reconciler must repair index in both directions

### DIFF
--- a/lib/wanderer_notifier/map/reconciler.ex
+++ b/lib/wanderer_notifier/map/reconciler.ex
@@ -13,15 +13,22 @@ defmodule WandererNotifier.Map.Reconciler do
 
   If an SSE event is lost — e.g. a client dies silently during a long uptime
   (see commit cfe85c5c), a reconnect window drops an event, or the upstream
-  misses a delete — the reverse index becomes permanently stale and the
-  pipeline keeps fanning killmail notifications out to maps that no longer
-  track the system. Users see "ghost" kill notifications for systems that
-  were removed from their map, sometimes more than a day after removal.
+  misses a delete — the reverse index becomes permanently out of sync. Two
+  failure modes follow:
 
-  This reconciler closes that gap by re-fetching the authoritative system
-  list from the map API every hour and pruning any reverse-index entries
-  that are no longer present upstream. It is intentionally a safety net, not
-  a replacement for SSE delta events — those remain the fast path.
+    * Lost `deleted_system` event → reverse index keeps a ghost entry; the
+      pipeline keeps fanning killmail notifications out to a map that no
+      longer tracks the system.
+    * Lost `add_system` event → reverse index is missing a real entry; the
+      WebSocket subscription never includes the new system, and killmails
+      for it are silently dropped until process restart.
+
+  This reconciler closes both gaps by re-fetching the authoritative system
+  list from the map API every 15 minutes and reconciling the reverse index
+  in BOTH directions: deindexing entries upstream no longer reports AND
+  indexing entries upstream reports that the local index is missing. It is
+  intentionally a safety net, not a replacement for SSE delta events —
+  those remain the fast path.
 
   ## Safety properties
 
@@ -32,9 +39,16 @@ defmodule WandererNotifier.Map.Reconciler do
       empty list for any reason (transient bug, caching proxy returning stale
       200s, etc.) the reconcile is skipped for that map and existing state
       is preserved. A warning is logged.
+    * **Malformed responses never clobber state.** If upstream returns a
+      non-empty list whose entries all fail id normalization, the reconcile
+      is skipped and existing state is preserved.
     * **Errors never clobber state.** If the upstream returns an error
       (timeout, 5xx, connection refused) the reconcile is skipped for that
       map and existing state is preserved. A warning is logged.
+    * **Two-way repair.** When the upstream response is valid, the reverse
+      index is reconciled in both directions: stale entries are deindexed
+      AND missing entries are indexed. A one-way reconciler can only repair
+      lost-delete events; lost-add events would persist until restart.
     * **Per-map isolation.** Reconciles run under `Task.async_stream` with a
       concurrency cap; a failure on one map does not affect any other.
     * **Systems-only.** Character tracking is not reconciled — character
@@ -49,7 +63,7 @@ defmodule WandererNotifier.Map.Reconciler do
   alias WandererNotifier.Map.MapConfig
   alias WandererNotifier.Shared.Dependencies
 
-  @reconcile_interval :timer.hours(1)
+  @reconcile_interval :timer.minutes(15)
   @max_concurrency 5
   @task_timeout :timer.seconds(30)
 
@@ -261,15 +275,26 @@ defmodule WandererNotifier.Map.Reconciler do
       {:error, {:exception, Exception.message(e)}}
   end
 
+  # Two-way reconciliation: deindex entries upstream no longer reports, AND
+  # index entries upstream reports that we're missing locally. Without the
+  # second direction, a single missed SSE `add_system` event (e.g. dropped
+  # during a reconnect window) leaves the reverse index permanently short
+  # the new system, the WebSocket subscription never includes it, and
+  # killmails for that system are silently dropped until process restart.
+  # The reconciler is the ONLY safety net that runs post-startup, so it
+  # MUST repair gaps in both directions.
   defp prune_stale_systems(%MapConfig{slug: slug}, registry, fresh_id_set) do
     current_ids = slug |> registry.systems_for_map() |> MapSet.new()
     stale_ids = MapSet.difference(current_ids, fresh_id_set)
+    missing_ids = MapSet.difference(fresh_id_set, current_ids)
     stale_count = MapSet.size(stale_ids)
+    missing_count = MapSet.size(missing_ids)
 
-    if stale_count > 0 do
-      Logger.info("Reconciler: pruning stale systems from reverse index",
+    if stale_count > 0 or missing_count > 0 do
+      Logger.info("Reconciler: repairing reverse index drift",
         map_slug: slug,
         stale_count: stale_count,
+        missing_count: missing_count,
         current_count: MapSet.size(current_ids),
         fresh_count: MapSet.size(fresh_id_set),
         category: :reconcile
@@ -277,6 +302,7 @@ defmodule WandererNotifier.Map.Reconciler do
     end
 
     Enum.each(stale_ids, &deindex_one_safe(registry, slug, &1))
+    Enum.each(missing_ids, &index_one_safe(registry, slug, &1))
   end
 
   # Defensive deindex wrapper. The real MapRegistry.deindex_system/2 always
@@ -298,6 +324,28 @@ defmodule WandererNotifier.Map.Reconciler do
   defp log_deindex_failure(slug, system_id, reason) do
     Logger.warning(
       "Reconciler: failed to deindex stale system — continuing with remaining ids",
+      map_slug: slug,
+      system_id: system_id,
+      reason: inspect(reason),
+      category: :reconcile
+    )
+  end
+
+  # Symmetric to deindex_one_safe — used when the reconciler discovers a
+  # system that upstream tracks but the local reverse index is missing.
+  defp index_one_safe(registry, slug, system_id) do
+    case registry.index_system(slug, system_id) do
+      :ok -> :ok
+      {:ok, _} -> :ok
+      {:error, reason} -> log_index_failure(slug, system_id, reason)
+    end
+  rescue
+    e -> log_index_failure(slug, system_id, Exception.message(e))
+  end
+
+  defp log_index_failure(slug, system_id, reason) do
+    Logger.warning(
+      "Reconciler: failed to index missing system — continuing with remaining ids",
       map_slug: slug,
       system_id: system_id,
       reason: inspect(reason),

--- a/lib/wanderer_notifier/map/reconciler.ex
+++ b/lib/wanderer_notifier/map/reconciler.ex
@@ -162,11 +162,13 @@ defmodule WandererNotifier.Map.Reconciler do
     * `{:ok, :reconciled}` - fetch succeeded, diff was applied.
     * `{:ok, :skipped_empty}` - upstream returned an empty list; state
       intentionally left unchanged.
+    * `{:ok, :skipped_malformed}` - upstream returned a non-empty list whose
+      entries all failed id normalization; state intentionally left unchanged.
     * `{:error, reason}` - upstream fetch failed; state intentionally left
       unchanged.
   """
   @spec reconcile_map(MapConfig.t(), keyword()) ::
-          {:ok, :reconciled | :skipped_empty} | {:error, term()}
+          {:ok, :reconciled | :skipped_empty | :skipped_malformed} | {:error, term()}
   def reconcile_map(%MapConfig{} = map_config, opts \\ []) do
     registry = Keyword.get(opts, :registry, Dependencies.map_registry())
     fetch_fun = Keyword.get(opts, :fetch_fun, &default_fetch/1)
@@ -213,7 +215,7 @@ defmodule WandererNotifier.Map.Reconciler do
 
       {:ok, :skipped_malformed}
     else
-      prune_stale_systems(map_config, registry, fresh_id_set)
+      reconcile_systems(map_config, registry, fresh_id_set)
       {:ok, :reconciled}
     end
   end
@@ -283,7 +285,7 @@ defmodule WandererNotifier.Map.Reconciler do
   # killmails for that system are silently dropped until process restart.
   # The reconciler is the ONLY safety net that runs post-startup, so it
   # MUST repair gaps in both directions.
-  defp prune_stale_systems(%MapConfig{slug: slug}, registry, fresh_id_set) do
+  defp reconcile_systems(%MapConfig{slug: slug}, registry, fresh_id_set) do
     current_ids = slug |> registry.systems_for_map() |> MapSet.new()
     stale_ids = MapSet.difference(current_ids, fresh_id_set)
     missing_ids = MapSet.difference(fresh_id_set, current_ids)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule WandererNotifier.MixProject do
   def project do
     [
       app: :wanderer_notifier,
-      version: "6.1.3",
+      version: "6.1.4",
       elixir: "~> 1.19",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/wanderer_notifier/map/reconciler_test.exs
+++ b/test/wanderer_notifier/map/reconciler_test.exs
@@ -126,6 +126,83 @@ defmodule WandererNotifier.Map.ReconcilerTest do
       refute_received {:deindex, _, _}
     end
 
+    test "indexes systems present upstream but missing from the reverse index" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      # Local index only has 31000001; upstream tracks 31000001 + 31000002
+      # The missing one (31000002) MUST be indexed — without this, lost SSE
+      # add_system events are unrecoverable until restart.
+      stub(mock_registry, :systems_for_map, fn _slug -> ["31000001"] end)
+
+      stub(mock_registry, :index_system, fn slug, system_id ->
+        send(test_pid, {:index, slug, system_id})
+        :ok
+      end)
+
+      stub(mock_registry, :deindex_system, fn slug, system_id ->
+        send(test_pid, {:deindex, slug, system_id})
+        :ok
+      end)
+
+      fetch_fun = fn _map_config ->
+        {:ok,
+         [
+           %{"solar_system_id" => 31_000_001},
+           %{"solar_system_id" => 31_000_002}
+         ]}
+      end
+
+      assert {:ok, :reconciled} =
+               Reconciler.reconcile_map(build_map_config(),
+                 registry: mock_registry,
+                 fetch_fun: fetch_fun
+               )
+
+      # 31000002 is upstream-only — it MUST be indexed
+      assert_received {:index, @map_slug, "31000002"}
+      # 31000001 is in both — must NOT be re-indexed (avoid noise) and must NOT be deindexed
+      refute_received {:index, @map_slug, "31000001"}
+      refute_received {:deindex, _, _}
+    end
+
+    test "performs both deindex and index in the same pass when both directions drift" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      # Local: [a, b]; upstream: [b, c]. Should deindex a, index c.
+      stub(mock_registry, :systems_for_map, fn _slug -> ["31000001", "31000002"] end)
+
+      stub(mock_registry, :index_system, fn slug, system_id ->
+        send(test_pid, {:index, slug, system_id})
+        :ok
+      end)
+
+      stub(mock_registry, :deindex_system, fn slug, system_id ->
+        send(test_pid, {:deindex, slug, system_id})
+        :ok
+      end)
+
+      fetch_fun = fn _map_config ->
+        {:ok,
+         [
+           %{"solar_system_id" => 31_000_002},
+           %{"solar_system_id" => 31_000_003}
+         ]}
+      end
+
+      assert {:ok, :reconciled} =
+               Reconciler.reconcile_map(build_map_config(),
+                 registry: mock_registry,
+                 fetch_fun: fetch_fun
+               )
+
+      assert_received {:deindex, @map_slug, "31000001"}
+      assert_received {:index, @map_slug, "31000003"}
+      refute_received {:deindex, @map_slug, "31000002"}
+      refute_received {:index, @map_slug, "31000002"}
+    end
+
     test "accepts fresh systems with string solar_system_id" do
       test_pid = self()
       mock_registry = WandererNotifier.MockMapRegistry
@@ -163,6 +240,7 @@ defmodule WandererNotifier.Map.ReconcilerTest do
 
       stub(mock_registry, :all_maps, fn -> [map_a, map_b, map_c] end)
       stub(mock_registry, :systems_for_map, fn _slug -> [] end)
+      stub(mock_registry, :index_system, fn _slug, _id -> :ok end)
       stub(mock_registry, :deindex_system, fn _slug, _id -> :ok end)
 
       # One happy path, one empty upstream, one error
@@ -259,6 +337,10 @@ defmodule WandererNotifier.Map.ReconcilerTest do
 
       stub(mock_registry, :systems_for_map, fn _slug -> ["31000001", "31000002"] end)
 
+      # Index_system is called for the missing id (99999999) — keep it a no-op
+      # since this test focuses on deindex error handling.
+      stub(mock_registry, :index_system, fn _slug, _id -> :ok end)
+
       # One deindex errors, the other succeeds — the reconciler must still
       # attempt every stale id and not abort midway.
       stub(mock_registry, :deindex_system, fn slug, system_id ->
@@ -289,6 +371,49 @@ defmodule WandererNotifier.Map.ReconcilerTest do
         end)
 
       assert log =~ "failed to deindex stale system"
+    end
+
+    test "logs and continues when index returns an error for one missing id" do
+      test_pid = self()
+      mock_registry = WandererNotifier.MockMapRegistry
+
+      stub(mock_registry, :systems_for_map, fn _slug -> [] end)
+      stub(mock_registry, :deindex_system, fn _slug, _id -> :ok end)
+
+      # First missing id fails to index, second succeeds — must still attempt
+      # every missing id and not abort midway.
+      stub(mock_registry, :index_system, fn slug, system_id ->
+        case system_id do
+          "31000001" ->
+            send(test_pid, {:index_error, slug, system_id})
+            {:error, :boom}
+
+          _ ->
+            send(test_pid, {:index_ok, slug, system_id})
+            :ok
+        end
+      end)
+
+      fetch_fun = fn _map_config ->
+        {:ok,
+         [
+           %{"solar_system_id" => 31_000_001},
+           %{"solar_system_id" => 31_000_002}
+         ]}
+      end
+
+      log =
+        capture_log(fn ->
+          assert {:ok, :reconciled} =
+                   Reconciler.reconcile_map(build_map_config(),
+                     registry: mock_registry,
+                     fetch_fun: fetch_fun
+                   )
+        end)
+
+      assert_received {:index_error, @map_slug, "31000001"}
+      assert_received {:index_ok, @map_slug, "31000002"}
+      assert log =~ "failed to index missing system"
     end
 
     test "ignores fresh systems without a parseable solar_system_id" do


### PR DESCRIPTION
The reconciler only computed `stale = current ∖ fresh` and deindexed those entries. The other direction — `missing = fresh ∖ current` — was silently ignored, so a lost SSE `add_system` event left the reverse index missing that entry permanently. The WebSocket subscription would never include the new system and killmails for it would be silently dropped until restart.

Observed in prod: subscribed_systems stayed at a stale value for 5+ hours across multiple reconciler ticks while real kills happened on systems that should have been re-added. Restart was the only recovery.

Make reconciliation symmetric — deindex stale AND index missing — so the hourly safety net actually does what its docstring claims. Also reduce the interval from 1 hour to 15 minutes; with two-way repair the worst-case recovery time is now bounded by the interval rather than the next restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconciliation is now bidirectional—automatically adding missing systems as well as removing stale ones.

* **Bug Fixes**
  * Runs every 15 minutes for faster sync.
  * Safer handling of malformed upstream responses to avoid state corruption; indexing/deindexing proceed best-effort with warnings on individual failures.

* **Tests**
  * Expanded coverage for mixed stale/missing scenarios and continued reconciliation despite individual indexing failures.

* **Documentation**
  * Updated docs/spec to reflect new reconciliation semantics and failure modes.

* **Chores**
  * Project version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->